### PR TITLE
Catch inspection failures on connect (e.g. `print`), and improve maxargs syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ then you should be good to go!  `psygnal` aims to be a superset of those APIs
 [`check_nargs`](#connection-safety-number-of-arguments) and
 [`check_types`](#connection-safety-types)).
 
-<sub><sup> *Note: the name "`Signal`" is used here instead of `pyqtSignal`,
-following the `qtpy` and `PySide` convention.* </sup></sub>
+*Note: the name "`Signal`" is used here instead of `pyqtSignal`, following the
+`qtpy` and `PySide` convention.*
 
 ```py
 from psygnal import Signal
@@ -102,8 +102,8 @@ ValueError: Cannot connect slot 'i_require_two_arguments' with signature: (first
 Accepted signature: (p0: str, /)
 ```
 
-<sub><sup> *Note: Positional argument checking can be disabled with
-`connect(..., check_nargs=False)`* </sup></sub>
+*Note: Positional argument checking can be disabled with `connect(...,
+check_nargs=False)`*
 
 #### Extra positional arguments ignored
 
@@ -151,8 +151,8 @@ ValueError: Cannot connect slot 'i_expect_an_integer' with signature: (x: int):
 Accepted signature: (p0: str, /)
 ```
 
-<sub><sup>*Note: unlike Qt, `psygnal` does <strong>not</strong> perform any type
-coercion when emitting a value.*</sup></sub>
+*Note: unlike Qt, `psygnal` does **not** perform any type coercion when emitting
+a value.*
 
 ### Query the sender
 
@@ -175,9 +175,8 @@ obj.value_changed.emit(10)
 # Sent by <__main__.MyObj object at 0x1046a30d0>
 ```
 
-<sub><sup>*If you want the actual signal instance that is emitting the signal
-(`obj.value_changed` in the above example), use
-`Signal.current_emitter()`.*</sup></sub>
+*If you want the actual signal instance that is emitting the signal
+(`obj.value_changed` in the above example), use `Signal.current_emitter()`.*
 
 ### Emitting signals asynchronously (threading)
 
@@ -224,9 +223,10 @@ print("Hi, from main thread.")
 `threading.Thread` instance returned when calling `.emit(...,
 asynchronous=True)`.
 
-**Experimental!**  While thread-safety is the goal, ([`RLocks`](https://docs.python.org/3/library/threading.html#rlock-objects) are used during
-important state mutations) it is not guaranteed.  Please use at your own risk.
-Issues/PRs welcome.
+**Experimental!**  While thread-safety is the goal,
+([`RLocks`](https://docs.python.org/3/library/threading.html#rlock-objects) are
+used during important state mutations) it is not guaranteed.  Please use at your
+own risk. Issues/PRs welcome.
 
 ## Other similar libraries
 

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -63,7 +63,7 @@ class Signal:
 
     """
 
-    __slots__ = ("_signal_instances", "_name", "_signature")
+    __slots__ = ("_signal_instances", "_name", "_signature", "description")
 
     if TYPE_CHECKING:  # pragma: no cover
         _signature: Signature  # callback signature for this signal

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -345,17 +345,24 @@ class SignalInstance:
                 if check_nargs:
                     # make sure we have a compatible signature
                     # get the maximum number of arguments that we can pass to the slot
-                    slot_sig = signature(slot)
-                    minargs, maxargs = _acceptable_posarg_range(slot_sig)
-                    n_spec_params = len(spec.parameters)
-
-                    # if `slot` requires more arguments than we will provide, raise.
-                    if minargs > n_spec_params:
-                        extra = (
-                            f"- Slot requires at least {minargs} positional arguments, "
-                            f"but spec only provides {n_spec_params}"
+                    try:
+                        slot_sig = signature(slot)
+                    except ValueError as e:
+                        warnings.warn(
+                            str(e)
+                            + "To silence this warning, connect with check_nargs=False"
                         )
-                        self._raise_connection_error(slot, extra)
+                    else:
+                        minargs, maxargs = _acceptable_posarg_range(slot_sig)
+                        n_spec_params = len(spec.parameters)
+
+                        # if `slot` requires more arguments than we will provide, raise.
+                        if minargs > n_spec_params:
+                            extra = (
+                                f"- Slot requires at least {minargs} positional "
+                                f"arguments, but spec only provides {n_spec_params}"
+                            )
+                            self._raise_connection_error(slot, extra)
 
                 if check_types:
                     if slot_sig is None:  # pragma: no cover

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -349,8 +349,8 @@ class SignalInstance:
                         slot_sig = signature(slot)
                     except ValueError as e:
                         warnings.warn(
-                            str(e)
-                            + "To silence this warning, connect with check_nargs=False"
+                            f"{e}. To silence this warning, connect with "
+                            "`check_nargs=False`"
                         )
                     else:
                         minargs, maxargs = _acceptable_posarg_range(slot_sig)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -445,3 +445,8 @@ def test_asynchronous_emit():
         thread.join()
     assert a == [value]
     assert not Signal.current_emitter()
+
+
+def test_sig_unavailable():
+    e = Emitter()
+    e.one_int.connect(print)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -465,5 +465,11 @@ def test_asynchronous_emit():
 
 
 def test_sig_unavailable():
+    """In some cases, signature.inspect() fails on a callable, such as print.
+
+    We should still connect, but with a warning.
+    """
     e = Emitter()
-    e.one_int.connect(print)
+    e.one_int.connect(print, check_nargs=False)  # no warning
+    with pytest.warns(UserWarning):
+        e.one_int.connect(print)


### PR DESCRIPTION
turns out `inspect.signature(print)` doesn't always work, (and probably other things), so this catches those cases and warns