### PR TITLE
sigstubs

### DIFF
--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -17,6 +17,7 @@ class Emitter:
     one_int = Signal(int)
     two_int = Signal(int, int)
     str_int = Signal(str, int)
+    no_check = Signal(str, check_nargs_on_connect=False, check_types_on_connect=False)
 
 
 class MyObj:
@@ -407,6 +408,15 @@ def test_forward_refs_type_checking():
         e.signal.connect(r.methodA, check_types=True)
     with pytest.raises(ValueError):
         e.signal.connect(r.methodA_ref, check_types=True)
+
+
+def test_checking_off():
+    e = Emitter()
+
+    # the no_check signal was instantiated with check_[nargs/types] = False
+    @e.no_check.connect
+    def bad_in_many_ways(x: int, y, z):
+        ...
 
 
 def test_keyword_only_not_allowed():

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -465,11 +465,17 @@ def test_asynchronous_emit():
 
 
 def test_sig_unavailable():
-    """In some cases, signature.inspect() fails on a callable, such as print.
+    """In some cases, signature.inspect() fails on a callable, (many builtins).
 
     We should still connect, but with a warning.
     """
     e = Emitter()
-    e.one_int.connect(print, check_nargs=False)  # no warning
+    with pytest.warns(None):
+        e.one_int.connect(vars, check_nargs=False)  # no warning
+
     with pytest.warns(UserWarning):
-        e.one_int.connect(print)
+        e.one_int.connect(vars)
+
+    # we've special cased print... due to frequency of use.
+    with pytest.warns(None):
+        e.one_int.connect(print)  # no warning


### PR DESCRIPTION
This PR adds the ability to stub the signatures of certain common builtins, like `print` (which otherwise fails with inspect.signature).  

It also adds `check_nargs_on_connect` and `check_types_on_connect` arguments to the Signal and SignalInstance constructors