### PR TITLE
test working with qtbot

### DIFF
--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -525,21 +525,21 @@ class SignalInstance:
     def emit(
         self,
         *args: Any,
-        check_nargs: bool,
-        check_types: bool,
-        asynchronous: Literal[True],
-    ) -> Optional["EmitThread"]:
-        # will return `None` if emitter is blocked
+        check_nargs: bool = False,
+        check_types: bool = False,
+        asynchronous: Literal[False] = False,
+    ) -> None:
         ...  # pragma: no cover
 
     @overload
     def emit(
         self,
         *args: Any,
-        check_nargs: bool,
-        check_types: bool,
-        asynchronous: Literal[False],
-    ) -> None:
+        check_nargs: bool = False,
+        check_types: bool = False,
+        asynchronous: Literal[True],
+    ) -> Optional["EmitThread"]:
+        # will return `None` if emitter is blocked
         ...  # pragma: no cover
 
     def emit(

--- a/tests/test_qtbot.py
+++ b/tests/test_qtbot.py
@@ -1,0 +1,31 @@
+"""qtbot should work for testing!"""
+import operator
+
+import pytest
+
+from psygnal import Signal
+
+pytest.importorskip("pytestqt")
+
+
+def is_(*val):
+    def _inner(*other):
+        return operator.eq(other, val)
+
+    return _inner
+
+
+def test_wait_signals(qtbot):
+    class Emitter:
+        sig1 = Signal()
+        sig2 = Signal(int)
+        sig3 = Signal(int, int)
+
+    e = Emitter()
+    signals = [e.sig1, e.sig2, e.sig3, e.sig1]
+    checks = [is_(), is_(1), is_(2, 3), is_()]
+    with qtbot.waitSignals(signals, check_params_cbs=checks, order="strict"):
+        e.sig1.emit()
+        e.sig2.emit(1)
+        e.sig3.emit(2, 3)
+        e.sig1.emit()


### PR DESCRIPTION
This adds a test that demonstrates that pytest-qt can actually be used to test Signals from psygnal. (psygnal will never use Qt, but it's cool that you can still use stuff like `waitSignals` from qtbot)