### PR TITLE
Set SignalInstances directly as attributes on objects (fix bug with hashable signal holders)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ benchmark-all:
 
 # compare HEAD against main
 benchmark-compare:
-	asv compare --split --factor 1.1 --only-changed main HEAD
+	asv compare --split --factor 1.1 main HEAD

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -206,8 +206,9 @@ class Signal:
         # to instance.name ... this essentially breaks the descriptor,
         # (i.e. __get__ will never again be called for this instance, and we have no
         # idea how many instances are out there),
-        # but it allows us to prevent creating a key for this instance,
-        # which may not be hashable or weak-referenceable.
+        # but it allows us to prevent creating a key for this instance (which may
+        # not be hashable or weak-referenceable), and also provides a significant
+        # speedup on attribute access (affecting everything).
         setattr(instance, name, signal_instance)
         return signal_instance
 

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -544,3 +544,12 @@ def test_resume_with_initial():
         emitter.one_int.emit(2)
         emitter.one_int.emit(3)
     mock.assert_called_once_with(26)
+
+
+def test_signals_on_unhashables():
+    class Emitter(dict):
+        signal = Signal(int)
+
+    e = Emitter()
+    e.signal.connect(lambda x: print(x))
+    e.signal.emit(1)


### PR DESCRIPTION
fixes #27 

not sure if this will break other (unanticipated) things, so going to let this sit for a bit

h/t @Czaki