### PR TITLE
Avoid holding strong reference to decorated and partial methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,5 @@ benchmark-all:
 
 # compare HEAD against main
 benchmark-compare:
+	asv run -j 4 --interleave-processes --skip-existing main..HEAD --steps 2
 	asv compare --split --factor 1.1 main HEAD

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -6,7 +6,8 @@ import warnings
 import weakref
 from contextlib import contextmanager
 from functools import lru_cache, partial, reduce
-from inspect import Parameter, Signature, ismethod
+from inspect import Parameter, Signature
+from types import MethodType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -21,9 +22,7 @@ from typing import (
     Union,
     cast,
     overload,
-    Protocol,
 )
-from types import MethodType
 
 from typing_extensions import Literal
 
@@ -40,15 +39,14 @@ class PartialMeta(type):
     def __instancecheck__(cls, inst: object) -> bool:
         return isinstance(inst, partial) and isinstance(inst.func, MethodType)
 
+
 class Partial(metaclass=PartialMeta):
     func: MethodType
     args: List[Any]
     keywords: Dict
 
-    def __call__(self, *args: List[Any], **kwargs:Dict[str, Any]) -> Any:
+    def __call__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> Any:
         raise NotImplementedError
-
-
 
 
 def signature(obj: Any) -> inspect.Signature:

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -5,7 +5,7 @@ import threading
 import warnings
 import weakref
 from contextlib import contextmanager
-from functools import lru_cache, reduce
+from functools import lru_cache, reduce, wraps, partial
 from inspect import Parameter, Signature, ismethod
 from typing import (
     TYPE_CHECKING,
@@ -469,30 +469,11 @@ class SignalInstance:
         msg += f"\n\nAccepted signature: {self.signature}"
         raise ValueError(msg)
 
-    @staticmethod
-    def _get_proper_name(callback):
-        assert inspect.ismethod(callback)
-        obj = callback.__self__
-        if (
-            not hasattr(obj, callback.__name__)
-            or getattr(obj, callback.__name__) != callback
-        ):
-            # some decorators will alter method.__name__, so that obj.method
-            # will not be equal to getattr(obj, obj.method.__name__). We check
-            # for that case here and traverse to find the right method here.
-            for name in dir(obj):
-                meth = getattr(obj, name)
-                if inspect.ismethod(meth) and meth == callback:
-                    return obj, name
-            raise RuntimeError(
-                f"During bind method {callback} of object {obj} an error happen"
-            )
-        return obj, callback.__name__
-
     def _normalize_slot(self, slot: NormedCallback) -> NormedCallback:
         if ismethod(slot):
-            obj, name = self._get_proper_name(slot)  # type: ignore
-            return (weakref.ref(obj), name)
+            return _get_proper_name(slot)  # type: ignore
+        if isinstance(slot, partial):
+            return partial_weakref(slot)
         if isinstance(slot, tuple) and not isinstance(slot[0], weakref.ref):
             return (weakref.ref(slot[0]), slot[1])
         return slot
@@ -686,6 +667,9 @@ class SignalInstance:
                         if cb is None:  # pragma: no cover
                             rem.append(slot)  # object has changed?
                             continue
+                    elif hasattr(slot, "__ref__") and slot.__ref__() is None:
+                        rem.append(slot)  # add dead weakref
+                        continue
                     else:
                         cb = slot
 
@@ -933,3 +917,42 @@ def _is_subclass(left: AnyType, right: type) -> bool:
         if origin is Union:
             return any(issubclass(i, right) for i in get_args(left))
     return issubclass(left, right)
+
+
+def partial_weakref(partial_fun):
+    obj, name = _get_proper_name(partial_fun.func)
+    args_ = partial_fun.args
+    kwargs_ = partial_fun.keywords
+    def wrap(*args, **kwargs):
+        ob = obj()
+        if ob is None:
+            return
+        getattr(ob, name)(*args_, *args, **kwargs_, **kwargs)
+
+    wrap.__ref__ = obj
+    # wrap.__name__ = partial_fun.__name__
+    # wrap.__annotations__ = partial_fun.__annotations__
+    # wrap.__doc__ = partial_fun.__doc__
+
+    del partial_fun
+    return wrap
+
+
+def _get_proper_name(callback):
+    assert inspect.ismethod(callback)
+    obj = callback.__self__
+    if (
+            not hasattr(obj, callback.__name__)
+            or getattr(obj, callback.__name__) != callback
+    ):
+        # some decorators will alter method.__name__, so that obj.method
+        # will not be equal to getattr(obj, obj.method.__name__). We check
+        # for that case here and traverse to find the right method here.
+        for name in dir(obj):
+            meth = getattr(obj, name)
+            if inspect.ismethod(meth) and meth == callback:
+                return weakref.ref(obj), name
+        raise RuntimeError(
+            f"During bind method {callback} of object {obj} an error happen"
+        )
+    return weakref.ref(obj), callback.__name__

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -45,7 +45,7 @@ class PartialBoundMethod(metaclass=PartialBoundMethodMeta):
     keywords: Dict
 
     def __call__(self, *args: List[Any], **kwargs: Dict[str, Any]) -> Any:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 def signature(obj: Any) -> inspect.Signature:
@@ -960,7 +960,7 @@ def _get_proper_name(slot: MethodType) -> Tuple[weakref.ref, str]:
             if getattr(obj, name) == slot:
                 return weakref.ref(obj), name
         # we don't know what to do here.
-        raise RuntimeError(
+        raise RuntimeError(  # pragma: no cover
             f"Could not find method on {obj} corresponding to decorated function {slot}"
         )
     return weakref.ref(obj), slot.__name__

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -957,10 +957,10 @@ def partial_weakref(partial_fun: PartialBoundMethod) -> Callable:
 def _get_proper_name(slot: MethodType) -> tuple[weakref.ref, str]:
     obj = slot.__self__
     # some decorators will alter method.__name__, so that obj.method
-    # will not be equal to getattr(obj, obj.method.__name__). 
+    # will not be equal to getattr(obj, obj.method.__name__).
     # We check for that case here and find the proper name in the function's closures
     if getattr(obj, slot.__name__, None) != slot:
-        for c in slot.__closure__ or ():
+        for c in slot.__closure__ or ():  # type: ignore
             cname = getattr(c.cell_contents, "__name__", None)
             if cname and getattr(obj, cname, None) == slot:
                 return weakref.ref(obj), cname

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -35,12 +35,12 @@ _NULL = object()
 _SIG_CACHE: Dict[int, Signature] = {}
 
 
-class PartialMeta(type):
+class PartialBoundMethodMeta(type):
     def __instancecheck__(cls, inst: object) -> bool:
         return isinstance(inst, partial) and isinstance(inst.func, MethodType)
 
 
-class Partial(metaclass=PartialMeta):
+class PartialBoundMethod(metaclass=PartialBoundMethodMeta):
     func: MethodType
     args: List[Any]
     keywords: Dict
@@ -487,7 +487,7 @@ class SignalInstance:
     def _normalize_slot(self, slot: NormedCallback) -> NormedCallback:
         if isinstance(slot, MethodType):
             return _get_proper_name(slot)
-        if isinstance(slot, Partial):
+        if isinstance(slot, PartialBoundMethod):
             return partial_weakref(slot)
         if isinstance(slot, tuple) and not isinstance(slot[0], weakref.ref):
             return (weakref.ref(slot[0]), slot[1])
@@ -936,7 +936,7 @@ def _is_subclass(left: AnyType, right: type) -> bool:
     return issubclass(left, right)
 
 
-def partial_weakref(partial_fun: Partial) -> Callable:
+def partial_weakref(partial_fun: PartialBoundMethod) -> Callable:
     obj, name = _get_proper_name(partial_fun.func)
     args_ = partial_fun.args
     kwargs_ = partial_fun.keywords

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -954,6 +954,12 @@ def _get_proper_name(slot: MethodType) -> Tuple[weakref.ref, str]:
             cname = getattr(c.cell_contents, "__name__", None)
             if cname and getattr(obj, cname, None) == slot:
                 return weakref.ref(obj), cname
+        # slower, but catches cases like assigned functions
+        # that won't have function in closure
+        for name in reversed(dir(obj)):  # most dunder methods come first
+            if getattr(obj, name) == slot:
+                return weakref.ref(obj), name
+        # we don't know what to do here.
         raise RuntimeError(
             f"Could not find method on {obj} corresponding to decorated function {slot}"
         )

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -941,13 +941,13 @@ def partial_weakref(partial_fun: Partial) -> Callable:
     args_ = partial_fun.args
     kwargs_ = partial_fun.keywords
 
-    def wrap(*args, **kwargs):  # type: ignore
+    def wrap(*args: Any, **kwargs: Any) -> Any:
         ob = obj()
         if ob is None:
             return
         getattr(ob, name)(*args_, *args, **kwargs_, **kwargs)
 
-    wrap.__ref__ = obj  # type: ignore
+    setattr(wrap, '__ref__', obj)
 
     del partial_fun
     return wrap

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -472,7 +472,7 @@ class SignalInstance:
     def _normalize_slot(self, slot: NormedCallback) -> NormedCallback:
         if ismethod(slot):
             return _get_proper_name(slot)  # type: ignore
-        if isinstance(slot, partial):
+        if isinstance(slot, partial) and ismethod(slot.func):
             return partial_weakref(slot)
         if isinstance(slot, tuple) and not isinstance(slot[0], weakref.ref):
             return (weakref.ref(slot[0]), slot[1])

--- a/psygnal/_signal.py
+++ b/psygnal/_signal.py
@@ -947,7 +947,7 @@ def partial_weakref(partial_fun: Partial) -> Callable:
             return
         getattr(ob, name)(*args_, *args, **kwargs_, **kwargs)
 
-    setattr(wrap, '__ref__', obj)
+    setattr(wrap, "__ref__", obj)
 
     del partial_fun
     return wrap

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from psygnal import Signal, SignalInstance
+from psygnal._signal import _get_proper_name
 
 
 def stupid_decorator(fun):
@@ -58,6 +59,7 @@ class MyObj:
     def f_int_decorated_stupid(self, a: int): ...
     @good_decorator
     def f_int_decorated_good(self, a: int): ...
+    f_any_assigned = lambda self, a: None  # noqa
 
 
 def f_no_arg(): ...
@@ -288,7 +290,14 @@ def test_signal_instance_error():
 
 
 @pytest.mark.parametrize(
-    "slot", ["f_no_arg", "f_int_decorated_stupid", "f_int_decorated_good", "partial"]
+    "slot",
+    [
+        "f_no_arg",
+        "f_int_decorated_stupid",
+        "f_int_decorated_good",
+        "f_any_assigned",
+        "partial",
+    ],
 )
 def test_weakref(slot):
     """Test that a connected method doesn't hold strong ref."""
@@ -600,3 +609,10 @@ def test_debug_import(monkeypatch):
     import psygnal
 
     assert not psygnal._compiled
+
+
+def test_get_proper_name():
+    obj = MyObj()
+    assert _get_proper_name(obj.f_int_decorated_stupid)[1] == "f_int_decorated_stupid"
+    assert _get_proper_name(obj.f_int_decorated_good)[1] == "f_int_decorated_good"
+    assert _get_proper_name(obj.f_any_assigned)[1] == "f_any_assigned"

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -1,6 +1,7 @@
 import gc
 import time
 import weakref
+from functools import partial
 from inspect import Signature
 from types import FunctionType
 from typing import Optional
@@ -294,6 +295,13 @@ def test_weakrefs():
     emitter.one_int.connect(obj.f_int_decorated)
     assert len(emitter.one_int) == 1
     emitter.one_int.emit(1)
+    emitter.one_int.connect(partial(obj.f_int_int, 1))
+    assert len(emitter.one_int) == 2
+    ref = weakref.ref(obj)
+    del obj
+    gc.collect()
+    emitter.one_int.emit(1)  # this should trigger deletion
+    assert len(emitter.one_int) == 0
 
 
 def test_norm_slot():

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -11,6 +11,16 @@ import pytest
 from psygnal import Signal, SignalInstance
 
 
+def stupid_decorator(fun):
+    def _fun(*args, **kwargs):
+        fun(*args, **kwargs)
+
+    _fun.__annotations__ = fun.__annotations__
+    _fun.__name__ = "f_no_arg"
+    return _fun
+
+
+
 # fmt: off
 class Emitter:
     no_arg = Signal()
@@ -36,6 +46,8 @@ class MyObj:
     def f_vararg(self, *a): ...
     def f_vararg_varkwarg(self, *a, **b): ...
     def f_vararg_kwarg(self, *a, b=None): ...
+    @stupid_decorator
+    def f_int_decorated(self, a:int): ...
 
 
 def f_no_arg(): ...
@@ -277,6 +289,11 @@ def test_weakrefs():
     gc.collect()
     emitter.one_int.emit(1)  # this should trigger deletion
     assert len(emitter.one_int) == 0
+
+    obj = MyObj()
+    emitter.one_int.connect(obj.f_int_decorated)
+    assert len(emitter.one_int) == 1
+    emitter.one_int.emit(1)
 
 
 def test_norm_slot():

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -21,7 +21,6 @@ def stupid_decorator(fun):
     return _fun
 
 
-
 # fmt: off
 class Emitter:
     no_arg = Signal()
@@ -48,7 +47,7 @@ class MyObj:
     def f_vararg_varkwarg(self, *a, **b): ...
     def f_vararg_kwarg(self, *a, b=None): ...
     @stupid_decorator
-    def f_int_decorated(self, a:int): ...
+    def f_int_decorated(self, a: int): ...
 
 
 def f_no_arg(): ...
@@ -297,7 +296,6 @@ def test_weakrefs():
     emitter.one_int.emit(1)
     emitter.one_int.connect(partial(obj.f_int_int, 1))
     assert len(emitter.one_int) == 2
-    ref = weakref.ref(obj)
     del obj
     gc.collect()
     emitter.one_int.emit(1)  # this should trigger deletion


### PR DESCRIPTION
In this PR there is fix for selection of wrong select (most common case is decorator which not mock `__name__`)

Also partial mathods are unwrapped and weakref to base object is keep.

_edit_: ... an example of things being fixed here:

```py
def deco(fun):
    def _fun(*args):
        fun(*args)
    return _fun

class MyObj:
    @deco
    def method(self, a: int): ...
    assigned_func = lambda self, a: None

class Emitter:
    changed = Signal(int)

e = Emitter()
obj = MyObj()

# these would have failed
e.changed.connect(obj.method)
e.changed.connect(obj.assigned_func)

# this would have retained a strong reference
e.changed.connect(partial(obj.method))
```