### PR TITLE
Throttle

### DIFF
--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -653,3 +653,30 @@ def test_property_connect():
 
     with pytest.raises(AttributeError):
         emitter.one_int.connect_setattr(a, "y")
+
+
+def test_throttle():
+    class A:
+        s = Signal()
+    
+    t = None
+    def stopwatch():
+        nonlocal t
+        if t is None:
+            t = time.time()
+        else:
+            t = t - time.time()
+
+    a = A()
+
+    a.s.connect(stopwatch)
+    a.s.emit()
+    a.s.emit()
+    assert t <= 0.5
+    a.s.disconnect(stopwatch)
+
+    a.s.connect(stopwatch, throttle=500)
+    a.s.emit()
+    a.s.emit()
+    time.sleep(1)
+    assert t >= 1

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -658,8 +658,9 @@ def test_property_connect():
 def test_throttle():
     class A:
         s = Signal()
-    
+
     t = None
+
     def stopwatch():
         nonlocal t
         if t is None:


### PR DESCRIPTION
Attempt at implementing throttling for slots.

Admittedly I didn't do much here, but I'd like to hear if I'm on the right track :)

Main thing I don't know how to tackle is: where should a thread with a timer be created? My first thought is that the `_run_emit_loop` method should have two different queues:

- one for normal slots where the callbacks are just fired
- one for throttled slots where instead of firing the callback, it pushes a new event onto the stack that the thread is consuming

If so, I should also overload the `self._slots.append()` situation with creating the respective threads.

Makes sense?
