### PR TITLE
add debug_events util

### DIFF
--- a/psygnal/utils.py
+++ b/psygnal/utils.py
@@ -1,0 +1,28 @@
+"""misc utils."""
+from contextlib import contextmanager
+from functools import partial
+from typing import Any, Callable, Iterator
+
+from ._signal import SignalInstance
+
+
+@contextmanager
+def debug_events(obj: Any, logger: Callable[[str], None] = print) -> Iterator[None]:
+    """Context manager to print events emitted SignalInstances on `obj`."""
+    disconnectors = []
+    for n in dir(obj):
+        attr = getattr(obj, n)
+        if isinstance(attr, SignalInstance):
+
+            def _report(*args: Any, _n: str = n) -> None:
+                msg = f"{_n}.emit{args!r}"
+                logger(msg)
+
+            attr.connect(_report)
+            disconnectors.append(partial(attr.disconnect, _report))
+
+    try:
+        yield
+    finally:
+        for disconnector in disconnectors:
+            disconnector()

--- a/psygnal/utils.py
+++ b/psygnal/utils.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, Iterator, Tuple
 
 from ._signal import SignalInstance
 
+__all__ = ["debug_events"]
+
 
 def _default_event_logger(event_name: str, args: Tuple[Any, ...]) -> None:
     print(f"{event_name}.emit{args!r}")

--- a/psygnal/utils.py
+++ b/psygnal/utils.py
@@ -1,13 +1,19 @@
 """misc utils."""
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, Tuple
 
 from ._signal import SignalInstance
 
 
+def _default_event_logger(event_name: str, args: Tuple[Any, ...]) -> None:
+    print(f"{event_name}.emit{args!r}")
+
+
 @contextmanager
-def debug_events(obj: Any, logger: Callable[[str], None] = print) -> Iterator[None]:
+def debug_events(
+    obj: Any, logger: Callable[[str, Tuple[Any, ...]], None] = _default_event_logger
+) -> Iterator[None]:
     """Context manager to print events emitted SignalInstances on `obj`."""
     disconnectors = []
     for n in dir(obj):
@@ -15,8 +21,7 @@ def debug_events(obj: Any, logger: Callable[[str], None] = print) -> Iterator[No
         if isinstance(attr, SignalInstance):
 
             def _report(*args: Any, _n: str = n) -> None:
-                msg = f"{_n}.emit{args!r}"
-                logger(msg)
+                logger(_n, args)
 
             attr.connect(_report)
             disconnectors.append(partial(attr.disconnect, _report))

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,7 @@ add_select = D402,D415,D417
 add_ignore = D105
 
 [tool:pytest]
-minversion = 7.0
+minversion = 6.0
 addopts = --mypy-ini-file=setup.cfg
 filterwarnings =
     error

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ add_select = D402,D415,D417
 add_ignore = D105
 
 [tool:pytest]
+minversion = 7.0
 addopts = --mypy-ini-file=setup.cfg
 filterwarnings =
     error

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if (
         # Only the last optimization flag will have effect
         os.environ["CFLAGS"] = "-O3 " + os.environ.get("CFLAGS", "")
         ext_modules = cythonize(
-            "psygnal/_signal.py",
+            ["psygnal/_signal.py", "psygnal/utils.py"],
             nthreads=int(os.getenv("CYTHON_NTHREADS", 0)),
             language_level=3,
             compiler_directives=compiler_directives,

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -523,15 +523,13 @@ def test_sig_unavailable():
     We should still connect, but with a warning.
     """
     e = Emitter()
-    with pytest.warns(None):
-        e.one_int.connect(vars, check_nargs=False)  # no warning
+    e.one_int.connect(vars, check_nargs=False)  # no warning
 
     with pytest.warns(UserWarning):
         e.one_int.connect(vars)
 
     # we've special cased print... due to frequency of use.
-    with pytest.warns(None):
-        e.one_int.connect(print)  # no warning
+    e.one_int.connect(print)  # no warning
 
 
 def test_pause():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+from unittest.mock import Mock, call
+
+from psygnal import Signal
+from psygnal.utils import debug_events
+
+
+def test_event_debugger(capsys):
+    """Test that the event debugger works"""
+
+    class M:
+        sig = Signal(int, int)
+
+    m = M()
+    _logger = Mock()
+
+    assert not m.sig._slots
+
+    with debug_events(m, _logger):
+        assert len(m.sig._slots) == 1
+        m.sig.emit(1, 2)
+        m.sig.emit(3, 4)
+
+    assert _logger.call_count == 2
+    _logger.assert_has_calls([call("sig", (1, 2)), call("sig", (3, 4))])
+    assert not m.sig._slots
+
+    with debug_events(m):
+        m.sig.emit(1, 2)
+        m.sig.emit(3, 4)
+
+    captured = capsys.readouterr()
+    assert captured.out == "sig.emit(1, 2)\nsig.emit(3, 4)\n"


### PR DESCRIPTION
simple helper context to print or otherwise collect/log events emitted within the context:

```python
from psygnal.utils import debug_events

with debug_events(some_object_with_signals):
    ...  # do something that will cause events
```

it takes an optional keyword argument `logger` that handles reporting the events, which, by default, simply prints events to stdout
```py
def _default_event_logger(event_name: str, args: Tuple[Any, ...]) -> None:
    print(f"{event_name}.emit{args!r}")
```