### PR TITLE
Add EventedObjectProxy

### DIFF
--- a/psygnal/containers/__init__.py
+++ b/psygnal/containers/__init__.py
@@ -1,10 +1,9 @@
 """Containers backed by psygnal events."""
 from ._evented_list import EventedList
-from ._evented_proxy import EventedCallableObjectProxy, EventedObjectProxy
+from ._evented_proxy import EventedObjectProxy
 from ._evented_set import EventedOrderedSet, EventedSet, OrderedSet
 
 __all__ = [
-    "EventedCallableObjectProxy",
     "EventedList",
     "EventedObjectProxy",
     "EventedOrderedSet",

--- a/psygnal/containers/__init__.py
+++ b/psygnal/containers/__init__.py
@@ -1,5 +1,13 @@
 """Containers backed by psygnal events."""
 from ._evented_list import EventedList
+from ._evented_proxy import EventedCallableObjectProxy, EventedObjectProxy
 from ._evented_set import EventedOrderedSet, EventedSet, OrderedSet
 
-__all__ = ["EventedList", "EventedSet", "EventedOrderedSet", "OrderedSet"]
+__all__ = [
+    "EventedCallableObjectProxy",
+    "EventedList",
+    "EventedObjectProxy",
+    "EventedOrderedSet",
+    "EventedSet",
+    "OrderedSet",
+]

--- a/psygnal/containers/__init__.py
+++ b/psygnal/containers/__init__.py
@@ -1,6 +1,7 @@
 """Containers backed by psygnal events."""
+from typing import Any
+
 from ._evented_list import EventedList
-from ._evented_proxy import EventedObjectProxy
 from ._evented_set import EventedOrderedSet, EventedSet, OrderedSet
 
 __all__ = [
@@ -10,3 +11,11 @@ __all__ = [
     "EventedSet",
     "OrderedSet",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "EventedObjectProxy":
+        from ._evented_proxy import EventedObjectProxy
+
+        return EventedObjectProxy
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/psygnal/containers/_evented_proxy.py
+++ b/psygnal/containers/_evented_proxy.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Generic, TypeVar
+from typing import Any, Dict, Generic, List, TypeVar
 from weakref import finalize
 
 from wrapt import ObjectProxy
@@ -7,16 +7,13 @@ from wrapt import ObjectProxy
 from .._group import SignalGroup
 from .._signal import Signal
 
-# we're using a cache instead of setting the events object directly on the proxy
-# because when wrapt is compiled as a C extensions, the ObjectProxy is not allowed
-# to add any new attributes.
-_OBJ_CACHE = {}
-
 T = TypeVar("T")
 _UNSET = object()
 
 
 class Events(SignalGroup):
+    """ObjectProxy events."""
+
     attribute_set = Signal(str, object)
     attribute_deleted = Signal(str)
     item_set = Signal(object, object)
@@ -25,10 +22,18 @@ class Events(SignalGroup):
 
 
 class CallableEvents(Events):
+    """CallableObjectProxy events."""
+
     called = Signal(tuple, dict)
 
 
-class _EventedObjectProxy(ObjectProxy, Generic[T]):
+# we're using a cache instead of setting the events object directly on the proxy
+# because when wrapt is compiled as a C extensions, the ObjectProxy is not allowed
+# to add any new attributes.
+_OBJ_CACHE: Dict[int, Events] = {}
+
+
+class _EventedObjectProxy(ObjectProxy, Generic[T]):  # type: ignore
     @property
     def events(self) -> Events:
         obj_id = id(self)
@@ -37,109 +42,116 @@ class _EventedObjectProxy(ObjectProxy, Generic[T]):
             finalize(self, partial(_OBJ_CACHE.pop, obj_id, None))
         return _OBJ_CACHE[obj_id]
 
-    def __setattr__(self, name, value):
-        if hasattr(type(self), name):
-            return object.__setattr__(self, name, value)
-
+    def __setattr__(self, name: str, value: None) -> None:
         before = getattr(self, name, _UNSET)
         super().__setattr__(name, value)
         after = getattr(self, name, _UNSET)
         if before is not after:
             self.events.attribute_set(name, after)
 
-    def __delattr__(self, name):
+    def __delattr__(self, name: str) -> None:
         super().__delattr__(name)
         self.events.attribute_deleted(name)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Any, value: Any) -> None:
         before = self[key]
         super().__setitem__(key, value)
         after = self[key]
         if before is not after:
             self.events.item_set(key, after)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: Any) -> None:
         super().__delitem__(key)
         self.events.item_deleted(key)
 
     def __repr__(self) -> str:
         return repr(self.__wrapped__)
 
-    def __dir__(self):
+    def __dir__(self) -> List[str]:
         return dir(self.__wrapped__) + ["events"]
 
-    def __getattr__(self, name):
-        if hasattr(type(self), name):
-            return object.__getattribute__(self, name)
-
-        return super().__getattr__(name)
-
-    def __iadd__(self, other):
+    def __iadd__(self, other: Any) -> T:
         self.events.in_place("add", other)
-        return super().__iadd__(other)
+        return super().__iadd__(other)  # type: ignore
 
-    def __isub__(self, other):
+    def __isub__(self, other: Any) -> T:
         self.events.in_place("sub", other)
-        return super().__isub__(other)
+        return super().__isub__(other)  # type: ignore
 
-    def __imul__(self, other):
+    def __imul__(self, other: Any) -> T:
         self.events.in_place("mul", other)
-        return super().__imul__(other)
+        return super().__imul__(other)  # type: ignore
 
-    def __idiv__(self, other):
-        self.events.in_place("div", other)
-        return super().__idiv__(other)
+    def __imatmul__(self, other: Any) -> T:
+        self.events.in_place("matmul", other)
+        self.__wrapped__ @= other  # not in wrapt  # type: ignore
+        return self
 
-    def __itruediv__(self, other):
+    def __itruediv__(self, other: Any) -> T:
         self.events.in_place("truediv", other)
-        return super().__itruediv__(other)
+        return super().__itruediv__(other)  # type: ignore
 
-    def __ifloordiv__(self, other):
+    def __ifloordiv__(self, other: Any) -> T:
         self.events.in_place("floordiv", other)
-        return super().__ifloordiv__(other)
+        return super().__ifloordiv__(other)  # type: ignore
 
-    def __imod__(self, other):
+    def __imod__(self, other: Any) -> T:
         self.events.in_place("mod", other)
-        return super().__imod__(other)
+        return super().__imod__(other)  # type: ignore
 
-    def __ipow__(self, other):
+    def __ipow__(self, other: Any) -> T:
         self.events.in_place("pow", other)
-        return super().__ipow__(other)
+        return super().__ipow__(other)  # type: ignore
 
-    def __ilshift__(self, other):
+    def __ilshift__(self, other: Any) -> T:
         self.events.in_place("lshift", other)
-        return super().__ilshift__(other)
+        return super().__ilshift__(other)  # type: ignore
 
-    def __irshift__(self, other):
+    def __irshift__(self, other: Any) -> T:
         self.events.in_place("rshift", other)
-        return super().__irshift__(other)
+        return super().__irshift__(other)  # type: ignore
 
-    def __iand__(self, other):
+    def __iand__(self, other: Any) -> T:
         self.events.in_place("and", other)
-        return super().__iand__(other)
+        return super().__iand__(other)  # type: ignore
 
-    def __ixor__(self, other):
+    def __ixor__(self, other: Any) -> T:
         self.events.in_place("xor", other)
-        return super().__ixor__(other)
+        return super().__ixor__(other)  # type: ignore
 
-    def __ior__(self, other):
+    def __ior__(self, other: Any) -> T:
         self.events.in_place("or", other)
-        return super().__ior__(other)
+        return super().__ior__(other)  # type: ignore
 
 
 class _EventedCallableObjectProxy(_EventedObjectProxy):
     @property
-    def events(self) -> Events:
+    def events(self) -> CallableEvents:
         obj_id = id(self)
         if obj_id not in _OBJ_CACHE:
             _OBJ_CACHE[obj_id] = CallableEvents()
             finalize(self, partial(_OBJ_CACHE.pop, obj_id, None))
-        return _OBJ_CACHE[obj_id]
+        return _OBJ_CACHE[obj_id]  # type: ignore
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         self.events.called(args, kwargs)
         return self.__wrapped__(*args, **kwargs)
 
 
 def EventedObjectProxy(target: T) -> T:
-    return _EventedObjectProxy(target)
+    """Create a proxy of `target` that includes an `events` SignalGroup.
+
+    The events available at target.events include:
+        attribute_set = Signal(str, object)
+        attribute_deleted = Signal(str)
+        item_set = Signal(object, object)
+        item_deleted = Signal(object)
+        in_place = Signal(str, object)
+
+    and if `target` is callable:
+        called = Signal(tuple, dict)
+    """
+    if callable(target):
+        return _EventedCallableObjectProxy(target)
+    else:
+        return _EventedObjectProxy(target)

--- a/psygnal/containers/_evented_proxy.py
+++ b/psygnal/containers/_evented_proxy.py
@@ -1,0 +1,145 @@
+from functools import partial
+from typing import Generic, TypeVar
+from weakref import finalize
+
+from wrapt import ObjectProxy
+
+from .._group import SignalGroup
+from .._signal import Signal
+
+# we're using a cache instead of setting the events object directly on the proxy
+# because when wrapt is compiled as a C extensions, the ObjectProxy is not allowed
+# to add any new attributes.
+_OBJ_CACHE = {}
+
+T = TypeVar("T")
+_UNSET = object()
+
+
+class Events(SignalGroup):
+    attribute_set = Signal(str, object)
+    attribute_deleted = Signal(str)
+    item_set = Signal(object, object)
+    item_deleted = Signal(object)
+    in_place = Signal(str, object)
+
+
+class CallableEvents(Events):
+    called = Signal(tuple, dict)
+
+
+class _EventedObjectProxy(ObjectProxy, Generic[T]):
+    @property
+    def events(self) -> Events:
+        obj_id = id(self)
+        if obj_id not in _OBJ_CACHE:
+            _OBJ_CACHE[obj_id] = Events()
+            finalize(self, partial(_OBJ_CACHE.pop, obj_id, None))
+        return _OBJ_CACHE[obj_id]
+
+    def __setattr__(self, name, value):
+        if hasattr(type(self), name):
+            return object.__setattr__(self, name, value)
+
+        before = getattr(self, name, _UNSET)
+        super().__setattr__(name, value)
+        after = getattr(self, name, _UNSET)
+        if before is not after:
+            self.events.attribute_set(name, after)
+
+    def __delattr__(self, name):
+        super().__delattr__(name)
+        self.events.attribute_deleted(name)
+
+    def __setitem__(self, key, value):
+        before = self[key]
+        super().__setitem__(key, value)
+        after = self[key]
+        if before is not after:
+            self.events.item_set(key, after)
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        self.events.item_deleted(key)
+
+    def __repr__(self) -> str:
+        return repr(self.__wrapped__)
+
+    def __dir__(self):
+        return dir(self.__wrapped__) + ["events"]
+
+    def __getattr__(self, name):
+        if hasattr(type(self), name):
+            return object.__getattribute__(self, name)
+
+        return super().__getattr__(name)
+
+    def __iadd__(self, other):
+        self.events.in_place("add", other)
+        return super().__iadd__(other)
+
+    def __isub__(self, other):
+        self.events.in_place("sub", other)
+        return super().__isub__(other)
+
+    def __imul__(self, other):
+        self.events.in_place("mul", other)
+        return super().__imul__(other)
+
+    def __idiv__(self, other):
+        self.events.in_place("div", other)
+        return super().__idiv__(other)
+
+    def __itruediv__(self, other):
+        self.events.in_place("truediv", other)
+        return super().__itruediv__(other)
+
+    def __ifloordiv__(self, other):
+        self.events.in_place("floordiv", other)
+        return super().__ifloordiv__(other)
+
+    def __imod__(self, other):
+        self.events.in_place("mod", other)
+        return super().__imod__(other)
+
+    def __ipow__(self, other):
+        self.events.in_place("pow", other)
+        return super().__ipow__(other)
+
+    def __ilshift__(self, other):
+        self.events.in_place("lshift", other)
+        return super().__ilshift__(other)
+
+    def __irshift__(self, other):
+        self.events.in_place("rshift", other)
+        return super().__irshift__(other)
+
+    def __iand__(self, other):
+        self.events.in_place("and", other)
+        return super().__iand__(other)
+
+    def __ixor__(self, other):
+        self.events.in_place("xor", other)
+        return super().__ixor__(other)
+
+    def __ior__(self, other):
+        self.events.in_place("or", other)
+        return super().__ior__(other)
+
+
+class _EventedCallableObjectProxy(_EventedObjectProxy):
+    @property
+    def events(self) -> Events:
+        obj_id = id(self)
+        if obj_id not in _OBJ_CACHE:
+            _OBJ_CACHE[obj_id] = CallableEvents()
+            finalize(self, partial(_OBJ_CACHE.pop, obj_id, None))
+        return _OBJ_CACHE[obj_id]
+
+    def __call__(self, *args, **kwargs):
+        self.events.called(args, kwargs)
+        return self.__wrapped__(*args, **kwargs)
+
+
+def EventedObjectProxy(target: T) -> T:
+    return _EventedObjectProxy(target)

--- a/psygnal/containers/_evented_proxy.py
+++ b/psygnal/containers/_evented_proxy.py
@@ -2,7 +2,12 @@ from functools import partial
 from typing import Any, Dict, Generic, List, TypeVar
 from weakref import finalize
 
-from wrapt import ObjectProxy
+try:
+    from wrapt import ObjectProxy
+except ImportError as e:
+    raise type(e)(
+        f"{e}. Please `pip install psygnal[proxy]` to use EventedObjectProxies"
+    ) from e
 
 from .._group import SignalGroup
 from .._signal import Signal

--- a/psygnal/containers/_evented_proxy.py
+++ b/psygnal/containers/_evented_proxy.py
@@ -40,7 +40,7 @@ _OBJ_CACHE: Dict[int, Events] = {}
 
 class _EventedObjectProxy(ObjectProxy, Generic[T]):  # type: ignore
     @property
-    def events(self) -> Events:
+    def events(self) -> Events:  # pragma: no cover # unclear why
         obj_id = id(self)
         if obj_id not in _OBJ_CACHE:
             _OBJ_CACHE[obj_id] = Events()
@@ -131,7 +131,7 @@ class _EventedObjectProxy(ObjectProxy, Generic[T]):  # type: ignore
 
 class _EventedCallableObjectProxy(_EventedObjectProxy):
     @property
-    def events(self) -> CallableEvents:
+    def events(self) -> CallableEvents:  # pragma: no cover # unclear why
         obj_id = id(self)
         if obj_id not in _OBJ_CACHE:
             _OBJ_CACHE[obj_id] = CallableEvents()

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,6 +107,9 @@ disallow_any_generics = False
 [mypy-cython]
 ignore_missing_imports = True
 
+[mypy-wrapt]
+ignore_missing_imports = True
+
 [coverage:run]
 omit =
     psygnal/containers/__init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,3 +119,4 @@ exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
     @overload
+    except ImportError

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,9 @@ dev =
     pytest-mypy-plugins
     pytest-qt
     qtpy
+    wrapt
+proxy =
+    wrapt
 testing =
     PyQt5
     numpy
@@ -63,6 +66,7 @@ testing =
     pytest-mypy-plugins
     pytest-qt
     qtpy
+    wrapt
 
 [options.package_data]
 psygnal = py.typed

--- a/tests/containers/test_evented_proxy.py
+++ b/tests/containers/test_evented_proxy.py
@@ -119,7 +119,7 @@ def test_numpy_proxy():
     mock = Mock()
     with monitor_events(t.events, mock):
         t[0] = 2
-        name, (key, value) = mock.call_args.args
+        ((name, (key, value)), _) = tuple(mock.call_args)
         assert name == "item_set"
         assert key == 0
         assert np.array_equal(value, [2, 2, 2, 2])
@@ -127,7 +127,7 @@ def test_numpy_proxy():
 
         t[2:] = np.arange(8).reshape(2, 4)
 
-        name, (key, value) = mock.call_args.args
+        ((name, (key, value)), _) = tuple(mock.call_args)
         assert name == "item_set"
         assert key == slice(2, None, None)
         assert np.array_equal(value, [[0, 1, 2, 3], [4, 5, 6, 7]])

--- a/tests/containers/test_evented_proxy.py
+++ b/tests/containers/test_evented_proxy.py
@@ -1,0 +1,11 @@
+from psygnal.containers import EventedObjectProxy
+
+
+def test_evented_proxy():
+    class T:
+        def __init__(self) -> None:
+            self.x = 1
+            self.f = "f"
+
+    t = EventedObjectProxy(T())
+    assert t.x == 1

--- a/tests/containers/test_evented_proxy.py
+++ b/tests/containers/test_evented_proxy.py
@@ -1,4 +1,10 @@
-from psygnal.containers import EventedObjectProxy
+from unittest.mock import Mock, call
+
+import numpy as np
+
+from psygnal import SignalGroup
+from psygnal.containers import EventedObjectProxy, _evented_proxy
+from psygnal.utils import monitor_events
 
 
 def test_evented_proxy():
@@ -6,6 +12,148 @@ def test_evented_proxy():
         def __init__(self) -> None:
             self.x = 1
             self.f = "f"
+            self._list = [0, 1]
+
+        def __getitem__(self, key):
+            return self._list[key]
+
+        def __setitem__(self, key, value):
+            self._list[key] = value
+
+        def __delitem__(self, key):
+            del self._list[key]
 
     t = EventedObjectProxy(T())
+    assert "events" in dir(t)
     assert t.x == 1
+
+    mock = Mock()
+    with monitor_events(t.events, mock):
+        t.x = 2
+        t.f = "f"
+        del t.x
+        setattr(t, "y", "new")
+        t[0] = 7
+        t[0] = 7  # no event
+        del t[0]
+
+    assert mock.call_args_list == [
+        call("attribute_set", ("x", 2)),
+        call("attribute_deleted", ("x",)),
+        call("attribute_set", ("y", "new")),
+        call("item_set", (0, 7)),
+        call("item_deleted", (0,)),
+    ]
+
+
+def test_evented_proxy_ref():
+    class T:
+        def __init__(self) -> None:
+            self.x = 1
+
+    assert not _evented_proxy._OBJ_CACHE
+    t = EventedObjectProxy(T())
+    assert not _evented_proxy._OBJ_CACHE
+    assert isinstance(t.events, SignalGroup)  # this will actually create the group
+    assert len(_evented_proxy._OBJ_CACHE) == 1
+
+    del t  # this should clean up the object from the cache
+    assert not _evented_proxy._OBJ_CACHE
+
+
+def test_in_place_proxies():
+    # fmt: off
+    class T:
+        x = 0
+        def __iadd__(self, other): return self  # noqa
+        def __isub__(self, other): return self  # noqa
+        def __imul__(self, other): return self  # noqa
+        def __imatmul__(self, other): return self  # noqa
+        def __itruediv__(self, other): return self  # noqa
+        def __ifloordiv__(self, other): return self  # noqa
+        def __imod__(self, other): return self  # noqa
+        def __ipow__(self, other): return self  # noqa
+        def __ilshift__(self, other): return self  # noqa
+        def __irshift__(self, other): return self  # noqa
+        def __iand__(self, other): return self  # noqa
+        def __ixor__(self, other): return self  # noqa
+        def __ior__(self, other): return self  # noqa
+    # fmt: on
+
+    t = EventedObjectProxy(T())
+    mock = Mock()
+    with monitor_events(t.events, mock):
+        t += 1
+        mock.assert_called_with("in_place", ("add", 1))
+        t -= 2
+        mock.assert_called_with("in_place", ("sub", 2))
+        t *= 3
+        mock.assert_called_with("in_place", ("mul", 3))
+        t /= 4
+        mock.assert_called_with("in_place", ("truediv", 4))
+        t //= 5
+        mock.assert_called_with("in_place", ("floordiv", 5))
+        t @= 6
+        mock.assert_called_with("in_place", ("matmul", 6))
+        t %= 7
+        mock.assert_called_with("in_place", ("mod", 7))
+        t **= 8
+        mock.assert_called_with("in_place", ("pow", 8))
+        t <<= 9
+        mock.assert_called_with("in_place", ("lshift", 9))
+        t >>= 10
+        mock.assert_called_with("in_place", ("rshift", 10))
+        t &= 11
+        mock.assert_called_with("in_place", ("and", 11))
+        t ^= 12
+        mock.assert_called_with("in_place", ("xor", 12))
+        t |= 13
+        mock.assert_called_with("in_place", ("or", 13))
+
+
+def test_numpy_proxy():
+    ary = np.ones((4, 4))
+    t = EventedObjectProxy(ary)
+    assert repr(t) == repr(ary)
+
+    mock = Mock()
+    with monitor_events(t.events, mock):
+        t[0] = 2
+        name, (key, value) = mock.call_args.args
+        assert name == "item_set"
+        assert key == 0
+        assert np.array_equal(value, [2, 2, 2, 2])
+        mock.reset_mock()
+
+        t[2:] = np.arange(8).reshape(2, 4)
+
+        name, (key, value) = mock.call_args.args
+        assert name == "item_set"
+        assert key == slice(2, None, None)
+        assert np.array_equal(value, [[0, 1, 2, 3], [4, 5, 6, 7]])
+        mock.reset_mock()
+
+        t += 1
+        t -= 1
+        assert np.array_equal(
+            t, np.asarray([[2, 2, 2, 2], [1, 1, 1, 1], [0, 1, 2, 3], [4, 5, 6, 7]])
+        )
+        t *= [0, 0, 0, 0]
+        assert not t.any()
+
+    assert mock.call_args_list == [
+        call("in_place", ("add", 1)),
+        call("in_place", ("sub", 1)),
+        call("in_place", ("mul", [0, 0, 0, 0])),
+    ]
+
+
+def test_evented_callable_proxy():
+    calls = []
+
+    def f(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    ef = EventedObjectProxy(f)
+    ef(1, 2, foo="bar")
+    assert calls == [((1, 2), {"foo": "bar"})]


### PR DESCRIPTION
`from psygnal.containers import EventedObjectProxy`

Create a proxy of `target` that includes an `events` SignalGroup

    The events available at target.events include:
        attribute_set = Signal(str, object)
        attribute_deleted = Signal(str)
        item_set = Signal(object, object)
        item_deleted = Signal(object)
        in_place = Signal(str, object)

    and if `target` is callable:
        called = Signal(tuple, dict)

