### PR TITLE
add a magicgui test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: napari/magicgui
+          path: magicgui
 
       - uses: actions/setup-python@v2
         with:
@@ -124,13 +125,13 @@ jobs:
       - name: install
         run: |
           python -m pip install -U pip
-          pip install -e .[testing,pyside2]
-          pip install -e ./psygnal
+          pip install -e magicgui[testing,pyside2]
+          pip install -e psygnal
 
       - name: test magicgui
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: python -m pytest -v --color=yes
+          run: python -m pytest magicgui/tests -v --color=yes
 
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           python -m pip install -U pip
           pip install -e .
           pip install -e ./magicgui[testing]
+          pip install PySide2
 
       - name: test
         run: pytest magicgui/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,24 +109,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: psygnal
+
       - uses: actions/checkout@v2
         with:
           repository: napari/magicgui
-          path: magicgui
 
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-
+      - uses: tlambert03/setup-qt-libs@v1
       - name: install
         run: |
           python -m pip install -U pip
-          pip install -e ./magicgui[testing,pyqt5]
-          pip install -e .
+          pip install -e .[testing,pyside2]
+          pip install -e ./psygnal
 
-      - name: test
-        run: pytest -v
-        working-directory: magicgui
+      - name: test magicgui
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m pytest -v --color=yes
 
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,17 +116,17 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9"
 
       - name: install
         run: |
           python -m pip install -U pip
           pip install -e .
-          pip install -e ./magicgui[testing]
-          pip install PyQt5
+          pip install -e ./magicgui[testing,pyqt5]
 
       - name: test
-        run: pytest magicgui/tests
+        run: pytest -v
+        working-directory: magicgui
 
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           python -m pip install -U pip
           pip install -e .
           pip install -e ./magicgui[testing]
-          pip install PySide2
+          pip install PyQt5
 
       - name: test
         run: pytest magicgui/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,8 @@ jobs:
       - name: install
         run: |
           python -m pip install -U pip
-          pip install -e .
           pip install -e ./magicgui[testing,pyqt5]
+          pip install -e .
 
       - name: test
         run: pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,31 @@ jobs:
         with:
           fail_ci_if_error: true
 
+  test-magicgui:
+    name: test magicgui
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: napari/magicgui
+          path: magicgui
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: install
+        run: |
+          python -m pip install -U pip
+          pip install -e .
+          pip install -e ./magicgui[testing]
+
+      - name: test
+        run: pytest magicgui/tests
+
+
   build:
     name: Build wheels on ${{ matrix.os }}
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')


### PR DESCRIPTION
run magicgui tests during CI.  Though magicgui will no longer be trying to subclass psygnal anymore after magicgui 0.4.0, this will just make sure that any psygnal changes don't break magicgui (such as the _normalize_slot Attribute error in magicgui < 0.3.6 with psygnal >= 0.3.0