### PR TITLE
Don't use `repr(obj)` when checking for Qt emit signature

### DIFF
--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -689,3 +689,21 @@ def test_property_connect():
 
     with pytest.raises(AttributeError):
         emitter.one_int.connect_setattr(a, "y")
+
+
+def test_repr_not_used():
+    """Test that we don't use repr() or __call__ to check signature."""
+    mock = MagicMock()
+
+    class T:
+        def __repr__(self):
+            mock()
+            return "<REPR>"
+
+        def __call__(self):
+            mock()
+
+    t = T()
+    sig = SignalInstance()
+    sig.connect(t)
+    mock.assert_not_called()


### PR DESCRIPTION
An object __repr__ can, in some cases, evaluate or run code.   So we shouldn't use it as means of determining whether something is a bound qt signal instance `emit` method