### PR TITLE
Used custom tuple for cython compatibility

### DIFF
--- a/psygnal/_group.py
+++ b/psygnal/_group.py
@@ -8,28 +8,30 @@ the args that were emitted.
 
 """
 from contextlib import contextmanager
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Iterator,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
 
 from psygnal._signal import Signal, SignalInstance
 
 __all__ = ["EmissionInfo", "SignalGroup"]
 
 
-class EmissionInfo(NamedTuple):
+# this is a variant of a NamedTuple that works with Cython<3.0a7
+class EmissionInfo(tuple):
     """Tuple containing information about an emission event."""
 
     signal: SignalInstance
     args: Tuple[Any, ...]
+
+    def __new__(cls, signal: SignalInstance, args: Tuple[Any, ...]) -> "EmissionInfo":
+        """Create new object."""
+        obj = tuple.__new__(cls, (signal, args))
+        obj.signal = signal
+        obj.args = args
+        return obj
+
+    def __repr__(self) -> str:  # pragma: no cover
+        """Return repr(self)."""
+        return f"EmissionInfo(signal={self.signal}, args={self.args})"
 
 
 class _SignalGroupMeta(type):


### PR DESCRIPTION
In the last release, I tried to exempt some of the container stuff that breaks without the newest cython from cythonize.  But, named tuple was still failing.  This just uses a custom object instead of typing.NamedTuple