### PR TITLE
port `EventedDict` from napari

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus, --keep-runtime-typing]
@@ -39,7 +39,7 @@ repos:
       - id: pydocstyle
         files: psygnal/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.940
     hooks:
       - id: mypy
         exclude: tests

--- a/psygnal/containers/__init__.py
+++ b/psygnal/containers/__init__.py
@@ -1,12 +1,14 @@
 """Containers backed by psygnal events."""
 from typing import Any
 
+from ._evented_dict import EventedDict
 from ._evented_list import EventedList
 from ._evented_set import EventedOrderedSet, EventedSet, OrderedSet
 from ._selectable_evented_list import SelectableEventedList
 from ._selection import Selection
 
 __all__ = [
+    "EventedDict",
     "EventedList",
     "EventedObjectProxy",
     "EventedOrderedSet",

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -9,7 +9,7 @@ from typing import (
     Sequence,
     Type,
     TypeVar,
-    Union,
+    Union, Optional,
 )
 
 from .. import Signal, SignalGroup
@@ -23,7 +23,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
 
     def __init__(
         self,
-        data: Mapping[_K, _T] = None,
+        data: Optional[Mapping[_K, _T]] = None,
         basetype: Union[Type[_T], Sequence[Type[_T]]] = (),
     ):
         if data is None:
@@ -61,7 +61,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
             )
         return e
 
-    def __newlike__(self, iterable: MutableMapping[_K, _T]):  # noqa: D105
+    def __newlike__(self, iterable: MutableMapping[_K, _T]) -> MutableMapping[_K, _T]:  # noqa: D105
         new = self.__class__()
         # separating this allows subclasses to omit these from their `__init__`
         new._basetypes = self._basetypes

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -44,7 +44,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
     def __len__(self) -> int:  # noqa: D105
         return len(self._dict)
 
-    def __iter__(self) -> Iterator[_T]:  # noqa: D105
+    def __iter__(self) -> Iterator[_K]:  # noqa: D105
         return iter(self._dict)
 
     def __repr__(self):  # noqa: D105

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -61,7 +61,9 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
             )
         return e
 
-    def __newlike__(self, iterable: MutableMapping[_K, _T]) -> MutableMapping[_K, _T]:  # noqa: D105
+    def __newlike__(
+            self, iterable: MutableMapping[_K, _T]
+    ) -> "TypedMutableMapping[_K, _T]":  # noqa: D105
         new = self.__class__()
         # separating this allows subclasses to omit these from their `__init__`
         new._basetypes = self._basetypes

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -68,7 +68,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         new.update(**iterable)  # type: ignore
         return new
 
-    def copy(self) -> "TypedMutableMapping[_T]":
+    def copy(self) -> "TypedMutableMapping[_K, _T]":
         """Return a shallow copy of the dictionary."""
         return self.__newlike__(self)
 

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -1,15 +1,15 @@
 """Dict that emits events when altered."""
 
 from typing import (
-    Any,
     Dict,
     Iterator,
     Mapping,
     MutableMapping,
+    Optional,
     Sequence,
     Type,
     TypeVar,
-    Union, Optional,
+    Union,
 )
 
 from .. import Signal, SignalGroup
@@ -36,7 +36,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         self._dict[key] = self._type_check(value)
 
     def __delitem__(self, key: _K) -> None:  # noqa: D105
-        del self._dict[key]
+        del self._dict[key]  # pragma: nocover
 
     def __getitem__(self, key: _K) -> _T:  # noqa: D105
         return self._dict[key]
@@ -62,7 +62,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         return e
 
     def __newlike__(
-            self, iterable: MutableMapping[_K, _T]
+        self, iterable: MutableMapping[_K, _T]
     ) -> "TypedMutableMapping[_K, _T]":  # noqa: D105
         new = self.__class__()
         # separating this allows subclasses to omit these from their `__init__`

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -32,7 +32,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         self._basetypes = basetype if isinstance(basetype, Sequence) else (basetype,)
         self.update(data)
 
-    def __setitem__(self, key: _K, value: _T):  # noqa: D105
+    def __setitem__(self, key: _K, value: _T) -> None:  # noqa: D105
         self._dict[key] = self._type_check(value)
 
     def __delitem__(self, key: _K) -> None:  # noqa: D105

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -50,7 +50,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
     def __repr__(self):  # noqa: D105
         return str(self._dict)
 
-    def _type_check(self, e: Any) -> _T:
+    def _type_check(self, e: _T) -> _T:
         """Check the types of items if basetypes are set for the model."""
         if self._basetypes and not any(isinstance(e, t) for t in self._basetypes):
             raise TypeError(

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -138,9 +138,3 @@ class EventedDict(TypedMutableMapping[_K, _T]):
         self.events.removing.emit(key)
         item = self._dict.pop(key)
         self.events.removed.emit(key, item)
-
-    def key(self, value: _T):
-        """Return first instance of value."""
-        for k, v in self._dict.items():
-            if v is value or v == value:
-                return k

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -50,16 +50,16 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
     def __repr__(self):  # type: ignore
         return str(self._dict)
 
-    def _type_check(self, e: _T) -> _T:
+    def _type_check(self, value: _T) -> _T:
         """Check the types of items if basetypes are set for the model."""
-        if self._basetypes and not any(isinstance(e, t) for t in self._basetypes):
+        if self._basetypes and not any(isinstance(value, t) for t in self._basetypes):
             raise TypeError(
                 (
-                    f"Cannot add object with type {type(e)} to TypedDict expecting"
+                    f"Cannot add object with type {type(value)} to TypedDict expecting"
                     f"type {self._basetypes}"
                 ),
             )
-        return e
+        return value
 
     def __newlike__(
         self, iterable: MutableMapping[_K, _T]

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -36,7 +36,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         self._dict[key] = self._type_check(value)
 
     def __delitem__(self, key: _K) -> None:  # noqa: D105
-        del self._dict[key]  # pragma: nocover
+        del self._dict[key]  # pragma: no cover
 
     def __getitem__(self, key: _K) -> _T:  # noqa: D105
         return self._dict[key]

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -32,7 +32,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         self._basetypes = basetype if isinstance(basetype, Sequence) else (basetype,)
         self.update(data)
 
-    def __setitem__(self, key: int, value: _T):  # noqa: D105
+    def __setitem__(self, key: _K, value: _T):  # noqa: D105
         self._dict[key] = self._type_check(value)
 
     def __delitem__(self, key: _K) -> None:  # noqa: D105
@@ -139,7 +139,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
             super().__setitem__(key, value)
             self.events.changed.emit(key, old_value, value)
 
-    def __delitem__(self, key: _K):  # noqa: D105
+    def __delitem__(self, key: _K) -> None:  # noqa: D105
         self.events.removing.emit(key)
         item = self._dict.pop(key)
         self.events.removed.emit(key, item)

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -129,7 +129,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
         super().__init__(data, basetype)
 
     def __setitem__(self, key: _K, value: _T) -> None:  # noqa: D105
-        old_value = self._dict.get(key, None)
+        old_value = self._dict.get(key, None)  # type: ignore
         if value is old_value or value == old_value:
             return
         if old_value is None:

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -122,7 +122,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
 
     def __init__(
         self,
-        data: Mapping[_K, _T] = None,
+        data: Optional[Mapping[_K, _T]] = None,
         basetype: Union[Type[_T], Sequence[Type[_T]]] = (),
     ):
         self.events = DictEvents()

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -47,7 +47,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
     def __iter__(self) -> Iterator[_K]:  # noqa: D105
         return iter(self._dict)
 
-    def __repr__(self):  # noqa: D105
+    def __repr__(self):  # type: ignore
         return str(self._dict)
 
     def _type_check(self, e: _T) -> _T:

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -65,7 +65,7 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         new = self.__class__()
         # separating this allows subclasses to omit these from their `__init__`
         new._basetypes = self._basetypes
-        new.update(**iterable)
+        new.update(**iterable)  # type: ignore
         return new
 
     def copy(self) -> "TypedMutableMapping[_T]":

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -1,0 +1,146 @@
+"""Dict that emits events when altered."""
+
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
+
+from .. import Signal, SignalGroup
+
+_K = TypeVar("_K")
+_T = TypeVar("_T")
+
+
+class TypedMutableMapping(MutableMapping[_K, _T]):
+    """Dictionary mixin that enforces item type."""
+
+    def __init__(
+        self,
+        data: Mapping[_K, _T] = None,
+        basetype: Union[Type[_T], Sequence[Type[_T]]] = (),
+    ):
+        if data is None:
+            data = {}
+        self._dict: Dict[_K, _T] = dict()
+        self._basetypes = basetype if isinstance(basetype, Sequence) else (basetype,)
+        self.update(data)
+
+    def __setitem__(self, key: int, value: _T):  # noqa: F811
+        self._dict[key] = self._type_check(value)
+
+    def __delitem__(self, key: _K) -> None:
+        del self._dict[key]
+
+    def __getitem__(self, key: _K) -> _T:
+        return self._dict[key]
+
+    def __len__(self) -> int:
+        return len(self._dict)
+
+    def __iter__(self) -> Iterator[_T]:
+        return iter(self._dict)
+
+    def __repr__(self):
+        return str(self._dict)
+
+    def _type_check(self, e: Any) -> _T:
+        if self._basetypes and not any(isinstance(e, t) for t in self._basetypes):
+            raise TypeError(
+                f"Cannot add object with type {type(e)} to TypedDict expecting type {self._basetypes}",
+            )
+        return e
+
+    def __newlike__(self, iterable: MutableMapping[_K, _T]):
+        new = self.__class__()
+        # separating this allows subclasses to omit these from their `__init__`
+        new._basetypes = self._basetypes
+        new.update(**iterable)
+        return new
+
+    def copy(self) -> "TypedMutableMapping[_T]":
+        """Return a shallow copy of the dictionary."""
+        return self.__newlike__(self)
+
+
+class DictEvents(SignalGroup):
+    """Events available on EventedDict.
+
+    Attributes
+    ----------
+    adding (key: _K)
+        emitted before an item is added at `key`
+    added (key: _K, value: _T)
+        emitted after a `value` is added at `key`
+    changing (key: _K, old_value: _T, value: _T)
+        emitted before `old_value` is replaced with `value` at `key`
+    changed (key: _K, old_value: _T, value: _T)
+        emitted before `old_value` is replaced with `value` at `key`
+    removing (key: _K)
+        emitted before an item is removed at `key`
+    removed (key: _K, value: _T)
+        emitted after `value` is removed at `index`
+    """
+
+    adding = Signal(object)  # (key, )
+    added = Signal(object, object)  # (key, value)
+    changing = Signal(object)  # (key, )
+    changed = Signal(object, object, object)  # (key, old_value, value)
+    removing = Signal(object)  # (key, )
+    removed = Signal(object, object)  # (key, value)
+
+
+class EventedDict(TypedMutableMapping[_K, _T]):
+    """Mutable dictionary that emits events when altered.
+    This class is designed to behave exactly like the builtin `dict`, but
+    will emit events before and after all mutations (addition, removal, and
+    changing).
+
+    Parameters
+    ----------
+    data : Mapping, optional
+        Dictionary to initialize the class with.
+    basetype : type of sequence of types, optional
+        Type of the element in the dictionary.
+
+    """
+
+    events: DictEvents  # pragma: no cover
+
+    def __init__(
+        self,
+        data: Mapping[_K, _T] = None,
+        basetype: Union[Type[_T], Sequence[Type[_T]]] = (),
+    ):
+        self.events = DictEvents()
+        super().__init__(data, basetype)
+
+    def __setitem__(self, key: _K, value: _T):
+        old_value = self._dict.get(key, None)
+        if value is old_value or value == old_value:
+            return
+        if old_value is None:
+            self.events.adding.emit(key)
+            super().__setitem__(key, value)
+            self.events.added.emit(key, value)
+        else:
+            self.events.changing.emit(key)
+            super().__setitem__(key, value)
+            self.events.changed.emit(key, old_value, value)
+
+    def __delitem__(self, key: _K):
+        self.events.removing.emit(key)
+        item = self._dict.pop(key)
+        self.events.removed.emit(key, item)
+
+    def key(self, value: _T):
+        """Return first instance of value."""
+        for k, v in self._dict.items():
+            if v is value or v == value:
+                return k

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -128,7 +128,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
         self.events = DictEvents()
         super().__init__(data, basetype)
 
-    def __setitem__(self, key: _K, value: _T):  # noqa: D105
+    def __setitem__(self, key: _K, value: _T) -> None:  # noqa: D105
         old_value = self._dict.get(key, None)
         if value is old_value or value == old_value:
             return

--- a/psygnal/containers/_evented_dict.py
+++ b/psygnal/containers/_evented_dict.py
@@ -32,32 +32,36 @@ class TypedMutableMapping(MutableMapping[_K, _T]):
         self._basetypes = basetype if isinstance(basetype, Sequence) else (basetype,)
         self.update(data)
 
-    def __setitem__(self, key: int, value: _T):  # noqa: F811
+    def __setitem__(self, key: int, value: _T):  # noqa: D105
         self._dict[key] = self._type_check(value)
 
-    def __delitem__(self, key: _K) -> None:
+    def __delitem__(self, key: _K) -> None:  # noqa: D105
         del self._dict[key]
 
-    def __getitem__(self, key: _K) -> _T:
+    def __getitem__(self, key: _K) -> _T:  # noqa: D105
         return self._dict[key]
 
-    def __len__(self) -> int:
+    def __len__(self) -> int:  # noqa: D105
         return len(self._dict)
 
-    def __iter__(self) -> Iterator[_T]:
+    def __iter__(self) -> Iterator[_T]:  # noqa: D105
         return iter(self._dict)
 
-    def __repr__(self):
+    def __repr__(self):  # noqa: D105
         return str(self._dict)
 
     def _type_check(self, e: Any) -> _T:
+        """Check the types of items if basetypes are set for the model."""
         if self._basetypes and not any(isinstance(e, t) for t in self._basetypes):
             raise TypeError(
-                f"Cannot add object with type {type(e)} to TypedDict expecting type {self._basetypes}",
+                (
+                    f"Cannot add object with type {type(e)} to TypedDict expecting"
+                    f"type {self._basetypes}"
+                ),
             )
         return e
 
-    def __newlike__(self, iterable: MutableMapping[_K, _T]):
+    def __newlike__(self, iterable: MutableMapping[_K, _T]):  # noqa: D105
         new = self.__class__()
         # separating this allows subclasses to omit these from their `__init__`
         new._basetypes = self._basetypes
@@ -98,6 +102,7 @@ class DictEvents(SignalGroup):
 
 class EventedDict(TypedMutableMapping[_K, _T]):
     """Mutable dictionary that emits events when altered.
+
     This class is designed to behave exactly like the builtin `dict`, but
     will emit events before and after all mutations (addition, removal, and
     changing).
@@ -121,7 +126,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
         self.events = DictEvents()
         super().__init__(data, basetype)
 
-    def __setitem__(self, key: _K, value: _T):
+    def __setitem__(self, key: _K, value: _T):  # noqa: D105
         old_value = self._dict.get(key, None)
         if value is old_value or value == old_value:
             return
@@ -134,7 +139,7 @@ class EventedDict(TypedMutableMapping[_K, _T]):
             super().__setitem__(key, value)
             self.events.changed.emit(key, old_value, value)
 
-    def __delitem__(self, key: _K):
+    def __delitem__(self, key: _K):  # noqa: D105
         self.events.removing.emit(key)
         item = self._dict.pop(key)
         self.events.removed.emit(key, item)

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -21,12 +21,11 @@ def test_dict(regular_dict):
 @pytest.mark.parametrize(
     "method_name, args, expected",
     [
-        ("__getitem__", ("A",), ()),  # read
-        ("__setitem__", ("A", 3), ("changed",)),  # update
-        ("__setitem__", ("D", 3), ("adding", "added")),  # add new entry
-        ("__delitem__", ("A",), ("removing", "removed")),  # delete
+        ("__getitem__", ("A",), 1),  # read
+        ("__setitem__", ("A", 3), None),  # update
+        ("__setitem__", ("D", 3), None),  # add new entry
+        ("__delitem__", ("A",), None),  # delete
         ("__len__", (), 3),
-        ("__repr__", (), "{'A': 1, 'B': 2, 'C': 3}"),
         ("__newlike__", ({"A": 1},), {"A": 1}),
         ("copy", (), {"A": 1, "B": 2, "C": 3}),
     ],
@@ -37,10 +36,21 @@ def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expec
     assert test_dict == regular_dict
     if hasattr(regular_dict, method_name):
         regular_dict_method = getattr(regular_dict, method_name)
-        assert test_dict_method(*args) == regular_dict_method(*args)
+        assert test_dict_method(*args) == regular_dict_method(*args) == expected
         assert test_dict == regular_dict
     else:
         test_dict_method(*args)  # smoke test
+
+
+def test_dict_inits():
+    a = EventedDict({"A": 1, "B": 2, "C": 3})
+    b = EventedDict(A=1, B=2, C=3)
+    c = EventedDict({"A": 1}, B=2, C=3)
+    assert a == b == c
+
+
+def test_dict_repr(test_dict):
+    assert repr(test_dict) == "EventedDict({'A': 1, 'B': 2, 'C': 3})"
 
 
 def test_instantiation_without_data():

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -38,6 +38,12 @@ def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expec
         test_dict_method(*args)  # smoke test
 
 
+def test_instantiation_without_data():
+    """Test that EventedDict can be instantiated without data."""
+    test_dict = EventedDict()
+    assert isinstance(test_dict, EventedDict)
+
+
 def test_dict_add_events(test_dict):
     """Test that events are emitted before and after an item is added."""
     test_dict.events.adding.emit = Mock(wraps=test_dict.events.adding.emit)

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -7,7 +7,7 @@ from psygnal.containers._evented_dict import EventedDict
 
 @pytest.fixture
 def regular_dict():
-    return {'A': 1, 'B': 2, 'C': 3}
+    return {"A": 1, "B": 2, "C": 3}
 
 
 @pytest.fixture
@@ -20,11 +20,11 @@ def test_dict(regular_dict):
 @pytest.mark.parametrize(
     "method_name, args, expected",
     [
-        ('__getitem__', ("A",), ()),  # read
-        ('__setitem__', ("A", 3), ('changed',)),  # update
-        ('__setitem__', ("D", 3), ('adding', 'added')),  # add new entry
-        ('__delitem__', ("A",), ('removing', 'removed')),  # delete
-    ]
+        ("__getitem__", ("A",), ()),  # read
+        ("__setitem__", ("A", 3), ("changed",)),  # update
+        ("__setitem__", ("D", 3), ("adding", "added")),  # add new entry
+        ("__delitem__", ("A",), ("removing", "removed")),  # delete
+    ],
 )
 def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expected):
     """Test that EventedDict interface is equivalent to the builtin dict."""

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -46,6 +46,26 @@ def test_dict_add_events(test_dict):
     test_dict.events.adding.emit.assert_called_with("D")
     test_dict.events.added.emit.assert_called_with("D", 4)
 
+    test_dict.events.adding.emit.reset_mock()
+    test_dict.events.added.emit.reset_mock()
+    test_dict["D"] = 4
+    test_dict.events.adding.emit.assert_not_called()
+    test_dict.events.added.emit.assert_not_called()
+
+
+def test_dict_change_events(test_dict):
+    """Test that events are emitted when an item in the dictionary is replaced."""
+    # events shouldn't be emitted on addition
+
+    test_dict.events.changing.emit = Mock(wraps=test_dict.events.changing.emit)
+    test_dict.events.changed.emit = Mock(wraps=test_dict.events.changed.emit)
+    test_dict["D"] = 4
+    test_dict.events.changing.emit.assert_not_called()
+    test_dict.events.changed.emit.assert_not_called()
+    test_dict["C"] = 4
+    test_dict.events.changing.emit.assert_called_with("C")
+    test_dict.events.changed.emit.assert_called_with("C", 3, 4)
+
 
 def test_dict_remove_events(test_dict):
     """Test that events are emitted before and after an item is removed."""

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -27,6 +27,7 @@ def test_dict(regular_dict):
         ("__delitem__", ("A",), ("removing", "removed")),  # delete
         ("__len__", (), 3),
         ("__repr__", (), "{'A': 1, 'B': 2, 'C': 3}"),
+        ("__newlike__", ({"A": 1},), {"A": 1}),
     ],
 )
 def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expected):

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -28,6 +28,7 @@ def test_dict(regular_dict):
         ("__len__", (), 3),
         ("__repr__", (), "{'A': 1, 'B': 2, 'C': 3}"),
         ("__newlike__", ({"A": 1},), {"A": 1}),
+        ("copy", (), {"A": 1, "B": 2, "C": 3}),
     ],
 )
 def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expected):

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -12,9 +12,9 @@ def regular_dict():
 
 @pytest.fixture
 def test_dict(regular_dict):
-    evented_dict = EventedDict(regular_dict)
-    evented_dict.events = Mock(wraps=evented_dict.events)
-    return EventedDict(regular_dict)
+    test_dict = EventedDict(regular_dict)
+    test_dict.events = Mock(wraps=test_dict.events)
+    return test_dict
 
 
 @pytest.mark.parametrize(
@@ -36,3 +36,9 @@ def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expec
         assert test_dict == regular_dict
     else:
         test_dict_method(*args)  # smoke test
+
+
+def test_events_on_add(test_dict):
+    """Test that events are emitted before and after an item is added."""
+    test_dict.events.adding.connect(lambda: print('whee'))
+    test_dict['D'] = 4

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -38,7 +38,19 @@ def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expec
         test_dict_method(*args)  # smoke test
 
 
-def test_events_on_add(test_dict):
+def test_dict_add_events(test_dict):
     """Test that events are emitted before and after an item is added."""
-    test_dict.events.adding.connect(lambda: print('whee'))
-    test_dict['D'] = 4
+    test_dict.events.adding.emit = Mock(wraps=test_dict.events.adding.emit)
+    test_dict.events.added.emit = Mock(wraps=test_dict.events.added.emit)
+    test_dict["D"] = 4
+    test_dict.events.adding.emit.assert_called_with("D")
+    test_dict.events.added.emit.assert_called_with("D", 4)
+
+
+def test_dict_remove_events(test_dict):
+    """Test that events are emitted before and after an item is removed."""
+    test_dict.events.removing.emit = Mock(wraps=test_dict.events.removing.emit)
+    test_dict.events.removed.emit = Mock(wraps=test_dict.events.removed.emit)
+    test_dict.pop("C")
+    test_dict.events.removing.emit.assert_called_with("C")
+    test_dict.events.removed.emit.assert_called_with("C", 3)

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -25,6 +25,7 @@ def test_dict(regular_dict):
         ("__setitem__", ("D", 3), ("adding", "added")),  # add new entry
         ("__delitem__", ("A",), ("removing", "removed")),  # delete
         ("__len__", (), 3),
+        ("__repr__", (), "{'A': 1, 'B': 2, 'C': 3}"),
     ],
 )
 def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expected):

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -12,6 +12,7 @@ def regular_dict():
 
 @pytest.fixture
 def test_dict(regular_dict):
+    """EventedDict without basetype set."""
     test_dict = EventedDict(regular_dict)
     test_dict.events = Mock(wraps=test_dict.events)
     return test_dict
@@ -44,6 +45,22 @@ def test_instantiation_without_data():
     """Test that EventedDict can be instantiated without data."""
     test_dict = EventedDict()
     assert isinstance(test_dict, EventedDict)
+
+
+def test_basetype_enforcement_on_instantiation():
+    """EventedDict with basetype set should enforce types on instantiation."""
+    with pytest.raises(TypeError):
+        test_dict = EventedDict({"A": "not an int"}, basetype=int)
+    test_dict = EventedDict({"A": 1})
+    assert isinstance(test_dict, EventedDict)
+
+
+def test_basetype_enforcement_on_set_item():
+    """EventedDict with basetype set should enforces types on setitem."""
+    test_dict = EventedDict(basetype=int)
+    test_dict["A"] = 1
+    with pytest.raises(TypeError):
+        test_dict["A"] = "not an int"
 
 
 def test_dict_add_events(test_dict):

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -24,6 +24,7 @@ def test_dict(regular_dict):
         ("__setitem__", ("A", 3), ("changed",)),  # update
         ("__setitem__", ("D", 3), ("adding", "added")),  # add new entry
         ("__delitem__", ("A",), ("removing", "removed")),  # delete
+        ("__len__", (), 3),
     ],
 )
 def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expected):

--- a/tests/containers/test_evented_dict.py
+++ b/tests/containers/test_evented_dict.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+
+import pytest
+
+from psygnal.containers._evented_dict import EventedDict
+
+
+@pytest.fixture
+def regular_dict():
+    return {'A': 1, 'B': 2, 'C': 3}
+
+
+@pytest.fixture
+def test_dict(regular_dict):
+    evented_dict = EventedDict(regular_dict)
+    evented_dict.events = Mock(wraps=evented_dict.events)
+    return EventedDict(regular_dict)
+
+
+@pytest.mark.parametrize(
+    "method_name, args, expected",
+    [
+        ('__getitem__', ("A",), ()),  # read
+        ('__setitem__', ("A", 3), ('changed',)),  # update
+        ('__setitem__', ("D", 3), ('adding', 'added')),  # add new entry
+        ('__delitem__', ("A",), ('removing', 'removed')),  # delete
+    ]
+)
+def test_dict_interface_parity(regular_dict, test_dict, method_name, args, expected):
+    """Test that EventedDict interface is equivalent to the builtin dict."""
+    test_dict_method = getattr(test_dict, method_name)
+    assert test_dict == regular_dict
+    if hasattr(regular_dict, method_name):
+        regular_dict_method = getattr(regular_dict, method_name)
+        assert test_dict_method(*args) == regular_dict_method(*args)
+        assert test_dict == regular_dict
+    else:
+        test_dict_method(*args)  # smoke test


### PR DESCRIPTION
This is pretty much a straight port of the `EventedDict` @lukasz-migas added to napari, using `SignalGroup` for the `DictEvents` rather than the napari event system

I removed a few little pieces that I wasn't sure about, namely
- child events
- `key` method on the dict
- the `update` event (changing/changed seem to cover the same cases)

Spent some time trying to please mypy too - typing is maybe starting to make some sense? 😆 I have likely made mistakes, please correct me if anything jumps out