### PR TITLE
feat: raise exceptions as EmitLoopError

### DIFF
--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "__version__",
     "_compiled",
     "EmissionInfo",
+    "EmitLoopError",
     "EventedModel",
     "Signal",
     "SignalGroup",
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
 
     Signal = _signal.Signal
     SignalInstance = _signal.SignalInstance
+    EmitLoopError = _signal.EmitLoopError
     _compiled = _signal._compiled
     SignalGroup = _group.SignalGroup
     EmissionInfo = _group.EmissionInfo
@@ -59,6 +61,7 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
 
     m = _import_purepy_mod("_signal")
     Signal, SignalInstance, _compiled = m.Signal, m.SignalInstance, m._compiled
+    EmitLoopError = m.EmitLoopError  # type: ignore
     m = _import_purepy_mod("_group")
     SignalGroup, EmissionInfo = m.SignalGroup, m.EmissionInfo
     m = _import_purepy_mod("_throttler")
@@ -67,7 +70,7 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
 
 else:
     from ._group import EmissionInfo, SignalGroup
-    from ._signal import Signal, SignalInstance, _compiled
+    from ._signal import EmitLoopError, Signal, SignalInstance, _compiled
     from ._throttler import debounced, throttled
 
 

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -907,7 +907,6 @@ class SignalInstance:
                     else:
                         cb = slot
 
-                    # TODO: add better exception handling
                     try:
                         cb(*args[:max_args])
                     except Exception as e:

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -35,6 +35,16 @@ ReducerFunc = Callable[[tuple, tuple], tuple]
 _NULL = object()
 
 
+class EmitLoopError(RuntimeError):
+    def __init__(self, slot: NormedCallback, args: Tuple, exc: BaseException) -> None:
+        self.slot = slot
+        self.args = args
+        super().__init__(
+            f"calling {slot} with args={args!r} caused "
+            f"{type(exc).__name__} in emit loop."
+        )
+
+
 class Signal:
     """Declares a signal emitter on a class.
 
@@ -898,7 +908,12 @@ class SignalInstance:
                         cb = slot
 
                     # TODO: add better exception handling
-                    cb(*args[:max_args])
+                    try:
+                        cb(*args[:max_args])
+                    except Exception as e:
+                        raise EmitLoopError(
+                            slot=slot, args=args[:max_args], exc=e
+                        ) from e
 
             for slot in rem:
                 self.disconnect(slot)


### PR DESCRIPTION
closes #106 by raising all emit loop errors as a special `EmitLoopError` exception (RuntimeError) type:

@ianhi, this gives the decision on how to handle (or suppress) to the thing doing the emitting:

```python
from contextlib import suppress
from psygnal import EmitLoopError

with suppress(EmitLoopError):
    obj.emitter.emit(...)
```


sound good?