### PR TITLE
feat: Add ability to disconnect slots from Signal group directly

### DIFF
--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -10,7 +10,7 @@ the args that were emitted.
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
 
-from psygnal._signal import Signal, SignalInstance
+from psygnal._signal import NormedCallback, Signal, SignalInstance
 
 __all__ = ["EmissionInfo", "SignalGroup"]
 
@@ -228,6 +228,28 @@ class SignalGroup(SignalInstance, metaclass=_SignalGroupMeta):
             yield
         finally:
             self.unblock()
+
+    def disconnect(
+        self, slot: Optional[NormedCallback] = None, missing_ok: bool = True
+    ) -> None:
+        """Disconnect slot from all signals.
+
+        Parameters
+        ----------
+        slot : callable, optional
+            The specific slot to disconnect.  If `None`, all slots will be disconnected,
+            by default `None`
+        missing_ok : bool, optional
+            If `False` and the provided `slot` is not connected, raises `ValueError.
+            by default `True`
+
+        Raises
+        ------
+        ValueError
+            If `slot` is not connected and `missing_ok` is False.
+        """
+        for signal in self.signals.values():
+            signal.disconnect(slot, missing_ok)
 
     def __repr__(self) -> str:
         """Return repr(self)."""

--- a/src/psygnal/_group.py
+++ b/src/psygnal/_group.py
@@ -250,6 +250,7 @@ class SignalGroup(SignalInstance, metaclass=_SignalGroupMeta):
         """
         for signal in self.signals.values():
             signal.disconnect(slot, missing_ok)
+        super().disconnect(slot, missing_ok)
 
     def __repr__(self) -> str:
         """Return repr(self)."""

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -132,3 +132,39 @@ def test_group_blocked_exclude():
         group.sig2.emit("hi")
     mock1.assert_not_called()
     mock2.assert_called_once_with("hi")
+
+
+def test_group_disconnect_single_slot():
+    """Test that we can disconnect single slots from groups."""
+    group = MyGroup()
+
+    mock1 = Mock()
+    mock2 = Mock()
+
+    group.sig1.connect(mock1)
+    group.sig2.connect(mock2)
+
+    group.disconnect(mock1)
+    group.sig1.emit()
+    mock1.assert_not_called()
+
+    group.sig2.emit()
+    mock2.assert_called_once()
+
+
+def test_group_disconnect_all_slots():
+    """Test that we can disconnect all slots from groups."""
+    group = MyGroup()
+
+    mock1 = Mock()
+    mock2 = Mock()
+
+    group.sig1.connect(mock1)
+    group.sig2.connect(mock2)
+
+    group.disconnect()
+    group.sig1.emit()
+    group.sig2.emit()
+
+    mock1.assert_not_called()
+    mock2.assert_not_called()


### PR DESCRIPTION
This PR adds a `SignalGroup.disconnect()` method which behaves as `Signal.disconnect()` does but for all signals in the group.

I'm circling back to the Qt stuff we talked about a while ago and this would be super convenient in some cases there :-)

I realise this method is overloading `SignalInstance.disconnect()` so the behaviour may be unexpected... open to alternative names 