### PR TITLE
build: pin cython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["setuptools>=45", "wheel", "Cython>=3.0a7", "setuptools-scm>=6.2"]
+requires = ["setuptools>=45", "wheel", "Cython==3.0a10", "setuptools-scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-build = ["Cython>=3.0a7;sys_platform != 'win32'"]
+build = ["Cython==3.0a10;sys_platform != 'win32'"]
 dev = [
     "black",
     "cruft",
@@ -69,7 +69,7 @@ docs = [
 proxy = ["wrapt"]
 pydantic = ["pydantic"]
 test = [
-    "cython",
+    "Cython==3.0a10",
     "dask",
     "numpy",
     "pydantic",


### PR DESCRIPTION
cython 3.0.0a11 appears to be breaking builds.  pinning to 3.0.0a10 until I can investigate more