### PR TITLE
fix: fix bug in setattr with private attrs

### DIFF
--- a/src/psygnal/_evented_model.py
+++ b/src/psygnal/_evented_model.py
@@ -316,7 +316,11 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             super().__setattr__(name, value)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name == "_events" or name not in self._events.signals:
+        if (
+            name == "_events"
+            or not hasattr(self, "_events")  # can happen on init
+            or name not in self._events.signals
+        ):
             # fallback to default behavior
             return self._super_setattr_(name, value)
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -489,3 +489,21 @@ def test_unrecognized_property_dependencies():
                 property_dependencies = {"y": ["b"]}
 
     assert "Unrecognized field dependency: 'b'" in str(e[0])
+
+
+def test_setattr_before_init():
+    from pydantic import PrivateAttr
+
+    class M(EventedModel):
+        _x: int = PrivateAttr()
+
+        def __init__(_model_self_, x: int, **data) -> None:
+            _model_self_._x = x
+            super().__init__(**data)
+
+        @property
+        def x(self) -> int:
+            return self._x
+
+    m = M(x=2)
+    assert m.x == 2


### PR DESCRIPTION
This PR fixes __setattr__  in the EventedModel when called before initialization (e.g. in a subclass, before calling super().__init__())