### PR TITLE
feat: add `@evented` decorator, turn any dataclass, attrs model, or pydantic model into evented

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,5 @@ repos:
     hooks:
       - id: mypy
         exclude: tests
+        additional_dependencies:
+          - "types-attrs"

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if (
         os.environ["CFLAGS"] = "-O3 " + os.environ.get("CFLAGS", "")
         ext_modules = cythonize(
             cython_modules,
-            exclude=["**/__init__.py"],
+            exclude=["**/__init__.py", "**/_evented_decorator.py"],
             nthreads=int(os.getenv("CYTHON_NTHREADS", 0)),
             language_level=3,
             compiler_directives=compiler_directives,

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -15,17 +15,20 @@ __email__ = "talley.lambert@gmail.com"
 __all__ = [
     "__version__",
     "_compiled",
+    "debounced",
     "EmissionInfo",
     "EmitLoopError",
+    "evented",
     "EventedModel",
     "Signal",
     "SignalGroup",
     "SignalInstance",
     "throttled",
-    "debounced",
 ]
 import os
 from typing import TYPE_CHECKING, Any
+
+from ._evented_decorator import evented
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -1,0 +1,111 @@
+import contextlib
+import operator
+import sys
+from dataclasses import fields, is_dataclass
+from functools import lru_cache
+from typing import Any, Callable, Dict, Iterator, Tuple, Type
+
+from ._group import SignalGroup
+from ._signal import Signal, SignalInstance
+
+_PARAMS = "__dataclass_params__"
+with contextlib.suppress(ImportError):
+    from dataclasses import _PARAMS  # type: ignore
+
+
+_NULL = object()
+EqOperator = Callable[[Any, Any], bool]
+
+_EQ_OPERATORS: Dict[Type, EqOperator] = {}
+
+
+def _check_field_equality(before: Any, after: Any, _fail: bool = False) -> bool:
+    if before is _NULL:
+        return after is _NULL
+
+    after_type = type(after)
+    are_equal = _EQ_OPERATORS.get(after_type, operator.eq)
+    try:
+        return bool(are_equal(after, before))
+    except Exception:
+        if _fail:
+            raise  # pragma: no cover
+
+        np = sys.modules.get("numpy", None)
+        if (
+            hasattr(after, "__array__")
+            and np is not None
+            and are_equal is not np.array_equal
+        ):
+            _EQ_OPERATORS[after_type] = np.array_equal
+            return _check_field_equality(before, after, _fail=False)
+        else:
+            _EQ_OPERATORS[after_type] = operator.is_
+            return _check_field_equality(before, after, _fail=True)
+
+
+def setattr_and_emit(obj: Any, name: str, value: Any) -> None:
+    if (
+        name == "_events"
+        or not hasattr(obj, "_events")  # can happen on init
+        or name not in obj._events.signals
+    ):
+        # fallback to default behavior
+        super(type(obj), obj).__setattr__(name, value)
+        return
+
+    # grab current value
+    before = getattr(obj, name, _NULL)
+
+    # set value using original setter
+    super(type(obj), obj).__setattr__(name, value)
+
+    # if different we emit the event with new value
+    after = getattr(obj, name)
+
+    if not _check_field_equality(before, after):
+        signal_instance: SignalInstance = getattr(obj.events, name)
+        signal_instance.emit(after)  # emit event
+
+
+def _pick_equality_operator(type_: Type) -> EqOperator:
+    import operator
+
+    return operator.eq
+
+
+def iter_fields(cls) -> Iterator[Tuple[str, Type]]:
+    """Iterate over all mutable fields in the class, including inherited fields."""
+
+    if is_dataclass(cls):
+        if getattr(cls, _PARAMS).frozen:
+            raise TypeError("Frozen dataclasses are not supported")
+
+        for field in fields(cls):
+            yield field.name, field.type
+
+
+@lru_cache
+def build_signal_group(cls):
+    signals = {}
+    for name, type_ in iter_fields(cls):
+        if type_ not in _EQ_OPERATORS:
+            _EQ_OPERATORS[type_] = _pick_equality_operator(type_)
+        signals[name] = Signal(type_)
+
+    return type(f"{cls.__name__}SignalGroup", (SignalGroup,), signals)
+
+
+def evented(cls):
+    original_init = cls.__init__
+
+    def new_init(self, *args, **kwargs) -> None:
+        print("new init")
+        self._events = build_signal_group(cls)()
+        original_init(self, *args)
+
+    cls.__setattr__ = setattr_and_emit
+    setattr(cls, "__init__", new_init)
+    print("set")
+    cls.events = property(lambda self: self._events)
+    return cls

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -19,13 +19,14 @@ from typing import (
     overload,
 )
 
-from pydantic import BaseModel
-
 from ._group import SignalGroup
 from ._signal import Signal, SignalInstance
 
 if TYPE_CHECKING:
     from typing import Literal, TypeGuard
+
+    from pydantic import BaseModel
+
 
 _DATACLASS_PARAMS = "__dataclass_params__"
 with contextlib.suppress(ImportError):

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -183,7 +183,7 @@ def _pick_equality_operator(type_: Type) -> EqOperator:
 
 @lru_cache(maxsize=None)
 def _build_dataclass_signal_group(
-    cls: type, equality_operators: Optional[Dict[str, EqOperator]] = None
+    cls: Type, equality_operators: Optional[Dict[str, EqOperator]] = None
 ) -> Type[SignalGroup]:
     """Build a SignalGroup with events for each field in a dataclass."""
     equality_operators = equality_operators or {}

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -1,9 +1,12 @@
 import contextlib
+import inspect
 import operator
 import sys
 from dataclasses import fields, is_dataclass
 from functools import lru_cache
-from typing import Any, Callable, Dict, Iterator, Tuple, Type
+from typing import Any, Callable, Dict, Iterator, Tuple, Type, TypeGuard, TypeVar, cast
+
+from pydantic import BaseModel
 
 from ._group import SignalGroup
 from ._signal import Signal, SignalInstance
@@ -12,20 +15,62 @@ _PARAMS = "__dataclass_params__"
 with contextlib.suppress(ImportError):
     from dataclasses import _PARAMS  # type: ignore
 
-
+T = TypeVar("T", bound=Type)
+_PRIVATE_EVENTS_GROUP = "_psygnal_group"
 _NULL = object()
+
 EqOperator = Callable[[Any, Any], bool]
+_EQ_OPERATORS: Dict[Type, Dict[str, EqOperator]] = {}
 
-_EQ_OPERATORS: Dict[Type, EqOperator] = {}
+_EQ_OPERATOR_NAME = "__eq_operators__"
 
 
-def _check_field_equality(before: Any, after: Any, _fail: bool = False) -> bool:
+def _get_eq_operator_map(cls: Type) -> Dict[str, EqOperator]:
+    # if the class has an __eq_operators__ attribute, we use it
+    # otherwise use/create the entry for `cls` in the global _EQ_OPERATORS map
+    if hasattr(cls, _EQ_OPERATOR_NAME):
+        return getattr(cls, _EQ_OPERATOR_NAME)  # type: ignore
+    else:
+        return _EQ_OPERATORS.setdefault(cls, {})
+
+
+def _check_field_equality(
+    cls: Type, name: str, before: Any, after: Any, _fail: bool = False
+) -> bool:
+    """ "Test if two values are equal for a given field.
+
+    This function will use the `__eq_operators__` attribute of the class if
+    present, otherwise it will use the default equality operator for the type.
+
+    Parameters
+    ----------
+    cls : type
+        The class that contains the field.
+    name : str
+        The name of the field.
+    before : Any
+        The value of the field before the change.
+    after : Any
+        The value of the field after the change.
+    _fail : bool, optional
+        If True, raise a ValueError if the field is not found in the class.
+        by default False
+
+    Returns
+    -------
+    bool
+        True if the values are equal, False otherwise.
+    """
+
     if before is _NULL:
         return after is _NULL
 
-    after_type = type(after)
-    are_equal = _EQ_OPERATORS.get(after_type, operator.eq)
+    eq_map = _get_eq_operator_map(cls)
+
+    # get and execute the equality operator for the field
+    are_equal = eq_map.setdefault(name, operator.eq)
     try:
+        # may fail depending on the __eq__ method for the type
         return bool(are_equal(after, before))
     except Exception:
         if _fail:
@@ -37,75 +82,147 @@ def _check_field_equality(before: Any, after: Any, _fail: bool = False) -> bool:
             and np is not None
             and are_equal is not np.array_equal
         ):
-            _EQ_OPERATORS[after_type] = np.array_equal
-            return _check_field_equality(before, after, _fail=False)
+            eq_map[name] = np.array_equal
+            return _check_field_equality(cls, name, before, after, _fail=False)
         else:
-            _EQ_OPERATORS[after_type] = operator.is_
-            return _check_field_equality(before, after, _fail=True)
+            eq_map[name] = operator.is_
+            return _check_field_equality(cls, name, before, after, _fail=True)
 
 
-def setattr_and_emit(obj: Any, name: str, value: Any) -> None:
-    if (
-        name == "_events"
-        or not hasattr(obj, "_events")  # can happen on init
-        or name not in obj._events.signals
-    ):
+def __setattr_and_emit__(self: Any, name: str, value: Any) -> None:
+    if name == _PRIVATE_EVENTS_GROUP:
         # fallback to default behavior
-        super(type(obj), obj).__setattr__(name, value)
+        # super(type(self), self).__setattr__(name, value)
+        object.__setattr__(self, name, value)
+        return
+
+    try:
+        group = getattr(self, _PRIVATE_EVENTS_GROUP)
+        signal_instance: SignalInstance = getattr(group, name)
+    except AttributeError:
+        super(type(self), self).__setattr__(name, value)
         return
 
     # grab current value
-    before = getattr(obj, name, _NULL)
+    before = getattr(self, name, _NULL)
 
     # set value using original setter
-    super(type(obj), obj).__setattr__(name, value)
+    super(type(self), self).__setattr__(name, value)
 
     # if different we emit the event with new value
-    after = getattr(obj, name)
+    after = getattr(self, name)
 
-    if not _check_field_equality(before, after):
-        signal_instance: SignalInstance = getattr(obj.events, name)
+    if not _check_field_equality(type(self), name, before, after):
         signal_instance.emit(after)  # emit event
 
 
-def _pick_equality_operator(type_: Type) -> EqOperator:
-    import operator
+def is_attrs_class(cls: Type) -> bool:
+    attr = sys.modules.get("attr", None)
+    return attr.has(cls) if attr is not None else False  # type: ignore
 
-    return operator.eq
+
+def is_pydantic_model(cls: Type) -> TypeGuard[BaseModel]:
+    pydantic = sys.modules.get("pydantic", None)
+    return pydantic is not None and issubclass(cls, pydantic.BaseModel)
 
 
-def iter_fields(cls) -> Iterator[Tuple[str, Type]]:
+def iter_fields(cls: Type) -> Iterator[Tuple[str, Type]]:
     """Iterate over all mutable fields in the class, including inherited fields."""
 
     if is_dataclass(cls):
         if getattr(cls, _PARAMS).frozen:
-            raise TypeError("Frozen dataclasses are not supported")
+            raise TypeError("Frozen dataclasses cannot be made evented.")
 
-        for field in fields(cls):
-            yield field.name, field.type
+        for d_field in fields(cls):
+            yield d_field.name, d_field.type
+
+    if is_attrs_class(cls):
+        import attr
+
+        for a_field in attr.fields(cls):
+            yield a_field.name, cast("type", a_field.type)
+
+    if is_pydantic_model(cls):
+        for p_field in cls.__fields__.values():
+            if p_field.field_info.allow_mutation:
+                yield p_field.name, p_field.outer_type_
 
 
-@lru_cache
-def build_signal_group(cls):
+def _pick_equality_operator(type_: Type) -> EqOperator:
+    np = sys.modules.get("numpy", None)
+    if np is not None and hasattr(type_, "__array__"):
+        return np.array_equal  # type: ignore
+    return operator.eq
+
+
+@lru_cache(maxsize=None)
+def _build_dataclass_signal_group(cls: type) -> Type[SignalGroup]:
     signals = {}
+    eq_map = _get_eq_operator_map(cls)
     for name, type_ in iter_fields(cls):
-        if type_ not in _EQ_OPERATORS:
-            _EQ_OPERATORS[type_] = _pick_equality_operator(type_)
+        eq_map.setdefault(name, _pick_equality_operator(type_))
         signals[name] = Signal(type_)
 
     return type(f"{cls.__name__}SignalGroup", (SignalGroup,), signals)
 
 
-def evented(cls):
-    original_init = cls.__init__
+def evented(cls: T | None = None, events_namespace: str = "events") -> T:
+    """A decorator to add events to a dataclass.
 
-    def new_init(self, *args, **kwargs) -> None:
-        print("new init")
-        self._events = build_signal_group(cls)()
-        original_init(self, *args)
+    note that this decorator will modify `cls` in place, as well as return it.
+    """
 
-    cls.__setattr__ = setattr_and_emit
-    setattr(cls, "__init__", new_init)
-    print("set")
-    cls.events = property(lambda self: self._events)
+    def _decorate(cls: T) -> T:
+        assert isinstance(cls, type), "evented can only be used on classes"
+        original_init = cls.__init__
+
+        def __evented_init__(self: Any, *args: Any, **kwargs: Any) -> None:
+            GroupCls = _build_dataclass_signal_group(cls)  # type: ignore
+            setattr(self, _PRIVATE_EVENTS_GROUP, GroupCls())
+            original_init(self, *args, **kwargs)
+
+        cls.__setattr__ = __setattr_and_emit__  # type: ignore
+        cls.__init__ = __evented_init__
+        cls.__init__.__doc__ == original_init.__doc__
+
+        if not hasattr(cls, "__signature__"):
+            cls.__signature__ = inspect.signature(original_init)
+
+        # expose the events as a property `events` by default, or as specified
+        events_prop = property(lambda s: getattr(s, _PRIVATE_EVENTS_GROUP))
+        setattr(cls, events_namespace, events_prop)
+
+        return _add_slots(cls) if _is_slot_cls(cls) else cls
+
+    return _decorate(cls) if cls is not None else _decorate
+
+
+def _is_slot_cls(cls: Type) -> bool:
+    return "__slots__" in cls.__dict__
+
+
+def _add_slots(cls: T) -> T:
+    # Need to create a new class, since we can't set __slots__
+    #  after a class has been created.
+
+    # Make sure __slots__ isn't already set.
+    cls_dict = dict(cls.__dict__)
+
+    __slots__ = {_PRIVATE_EVENTS_GROUP}
+    if "__slots__" in cls.__dict__:
+        for s in cls.__dict__["__slots__"]:
+            __slots__.add(s)
+            cls_dict.pop(s, None)
+
+    # Create a new dict for our new class.
+    cls_dict["__slots__"] = tuple(__slots__)
+    # Remove __dict__ itself.
+    cls_dict.pop("__dict__", None)
+
+    # And finally create the class.
+    qualname = getattr(cls, "__qualname__", None)
+    cls = type(cls)(cls.__name__, cls.__bases__, cls_dict)
+    if qualname is not None:
+        cls.__qualname__ = qualname
+
     return cls

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -257,14 +257,15 @@ def evented(
     TypeError
         If the class is frozen or is not a class.
     """
+    _eqop = tuple(equality_operators.items()) if equality_operators else None
 
     def _decorate(cls: T) -> T:
         assert isinstance(cls, type), "evented can only be used on classes"
         original_init = cls.__init__
 
+        Grp = _build_dataclass_signal_group(cls, _eqop)  # type: ignore
+
         def __evented_init__(self: Any, *args: Any, **kwargs: Any) -> None:
-            _eqop = tuple(equality_operators.items()) if equality_operators else None
-            Grp = _build_dataclass_signal_group(cls, _eqop)  # type: ignore
             setattr(self, _PRIVATE_EVENTS_GROUP, Grp())
             original_init(self, *args, **kwargs)
 

--- a/src/psygnal/_evented_decorator.py
+++ b/src/psygnal/_evented_decorator.py
@@ -55,8 +55,9 @@ def _check_field_equality(
 ) -> bool:
     """Test if two values are equal for a given field.
 
-    This function will use the `__eq_operators__` attribute of the class if
-    present, otherwise it will use the default equality operator for the type.
+    This function will look for a field-specific operator in the the `__eq_operators__`
+    attribute of the class if present, otherwise it will use the default equality
+    operator for the type.
 
     Parameters
     ----------

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -3,12 +3,16 @@ from unittest.mock import Mock
 
 import pytest
 
+from psygnal import SignalGroup
 from psygnal._evented_decorator import evented
 
 
 @no_type_check
 def _check_events(cls):
-    obj = cls(bar=1, baz=2)
+    obj = cls(bar=1, baz="2")
+
+    assert isinstance(obj.events, SignalGroup)
+    assert set(obj.events.signals) == {"bar", "baz"}
 
     mock = Mock()
     obj.events.bar.connect(mock)
@@ -18,54 +22,54 @@ def _check_events(cls):
     mock.assert_called_once_with(2)
 
     mock.reset_mock()
-    obj.baz = 3
+    obj.baz = "3"
     mock.assert_not_called()
 
 
 @pytest.mark.parametrize("slots", [True, False])
-def test_native_dataclass(slots: bool):
+def test_native_dataclass(slots: bool) -> None:
     from dataclasses import dataclass
 
     @evented
-    @dataclass(slots=slots)
+    @dataclass(slots=slots)  # type: ignore
     class Foo:
         bar: int
-        baz: int
+        baz: str
 
     _check_events(Foo)
 
 
 @pytest.mark.parametrize("slots", [True, False])
-def test_attrs_dataclass(slots: bool):
+def test_attrs_dataclass(slots: bool) -> None:
     from attrs import define
 
     @evented
-    @define(slots=slots)
+    @define(slots=slots)  # type: ignore
     class Foo:
         bar: int
-        baz: int
+        baz: str
 
     _check_events(Foo)
 
 
-def test_pydantic_dataclass():
+def test_pydantic_dataclass() -> None:
     from pydantic.dataclasses import dataclass
 
     @evented
     @dataclass
     class Foo:
         bar: int
-        baz: int
+        baz: str
 
     _check_events(Foo)
 
 
-def test_pydantic_base_model():
+def test_pydantic_base_model() -> None:
     from pydantic import BaseModel
 
     @evented
     class Foo(BaseModel):
         bar: int
-        baz: int
+        baz: str
 
     _check_events(Foo)

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -1,0 +1,71 @@
+from typing import no_type_check
+from unittest.mock import Mock
+
+import pytest
+
+from psygnal._evented_decorator import evented
+
+
+@no_type_check
+def _check_events(cls):
+    obj = cls(bar=1, baz=2)
+
+    mock = Mock()
+    obj.events.bar.connect(mock)
+    assert obj.bar == 1
+    obj.bar = 2
+    assert obj.bar == 2
+    mock.assert_called_once_with(2)
+
+    mock.reset_mock()
+    obj.baz = 3
+    mock.assert_not_called()
+
+
+@pytest.mark.parametrize("slots", [True, False])
+def test_native_dataclass(slots: bool):
+    from dataclasses import dataclass
+
+    @evented
+    @dataclass(slots=slots)
+    class Foo:
+        bar: int
+        baz: int
+
+    _check_events(Foo)
+
+
+@pytest.mark.parametrize("slots", [True, False])
+def test_attrs_dataclass(slots: bool):
+    from attrs import define
+
+    @evented
+    @define(slots=slots)
+    class Foo:
+        bar: int
+        baz: int
+
+    _check_events(Foo)
+
+
+def test_pydantic_dataclass():
+    from pydantic.dataclasses import dataclass
+
+    @evented
+    @dataclass
+    class Foo:
+        bar: int
+        baz: int
+
+    _check_events(Foo)
+
+
+def test_pydantic_base_model():
+    from pydantic import BaseModel
+
+    @evented
+    class Foo(BaseModel):
+        bar: int
+        baz: int
+
+    _check_events(Foo)

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -3,8 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from psygnal import SignalGroup
-from psygnal._evented_decorator import evented
+from psygnal import SignalGroup, evented
 
 
 @no_type_check

--- a/tests/test_evented_decorator.py
+++ b/tests/test_evented_decorator.py
@@ -1,3 +1,4 @@
+import sys
 from typing import no_type_check
 from unittest.mock import Mock
 
@@ -25,12 +26,17 @@ def _check_events(cls):
     mock.assert_not_called()
 
 
-@pytest.mark.parametrize("slots", [True, False])
-def test_native_dataclass(slots: bool) -> None:
+DCLASS_KWARGS = []
+if sys.version_info >= (3, 10):
+    DCLASS_KWARGS.extend([{"slots": True}, {"slots": False}])
+
+
+@pytest.mark.parametrize("kwargs", DCLASS_KWARGS)
+def test_native_dataclass(kwargs: dict) -> None:
     from dataclasses import dataclass
 
     @evented
-    @dataclass(slots=slots)  # type: ignore
+    @dataclass(**kwargs)
     class Foo:
         bar: int
         baz: str


### PR DESCRIPTION
Psygnal already has the `EventedModel`, which is a somewhat "heavy" subclass of a pydantic's BaseModel.

This PR adds a much lighter-weight `@evented` decorator that will turn any dataclass into an evented-dataclass.  It currently supports `dataclasses.dataclass` from the standard library, `attrs.define` from attrs, and will also work when decorating a plain pydantic model (one which was not built using `psygnal.EventedModel` (the difference here is that using `psygnal.EventedModel` will _also_ add support for things like property.setters, _json_encoders, etc... whereas just decorating with `@evented` simply adds the events)

basic idea:

```python
from dataclasses import dataclass
from psygnal import evented

@evented
@dataclass
class Foo:
    bar: int
    baz: str

foo = Foo(bar=1, baz="2")

@foo.events.bar.connect
def _some_callback(new_value):
    ...
```