### PR TITLE
fix: fix disconnection of partials

### DIFF
--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import time
 import weakref
 from contextlib import suppress
@@ -804,6 +805,12 @@ def test_partial_weakref():
         "f_int_decorated_good",
         "f_any_assigned",
         "partial",
+        pytest.param(
+            "partial",
+            marks=pytest.mark.xfail(
+                sys.version_info < (3, 8), reason="no idea why this fails on 3.7"
+            ),
+        ),
     ],
 )
 def test_weakref_disconnect(slot):

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -815,14 +815,23 @@ def test_partial_weakref():
 )
 def test_weakref_disconnect(slot):
     """Test that a connected method doesn't hold strong ref."""
+    from psygnal._signal import _PARTIAL_CACHE, _prune_partial_cache
+
     emitter = Emitter()
     obj = MyObj()
 
+    _prune_partial_cache()
+    assert not _PARTIAL_CACHE
+
     assert len(emitter.one_int) == 0
     cb = partial(obj.f_int_int, 1) if slot == "partial" else getattr(obj, slot)
+    cb_id = id(cb)
+    assert cb_id not in _PARTIAL_CACHE
     emitter.one_int.connect(cb)
+    assert (cb_id in _PARTIAL_CACHE) == (slot == "partial")
     assert len(emitter.one_int) == 1
     emitter.one_int.emit(1)
     assert len(emitter.one_int) == 1
     emitter.one_int.disconnect(cb)
     assert len(emitter.one_int) == 0
+    assert cb_id not in _PARTIAL_CACHE


### PR DESCRIPTION
fixes #37 ... sorry for the long delay on this one @Czaki!

note that I made a slight adjustment to your test in that issue (that makes it a little less awesome, but still better):

```python
    assert len(emitter.one_int) == 0
    # this is the change... storing the partial as `cb`
    # we have to connect/disconnect the *same* partial
    # which I think is a reasonable compromise... 
    cb = partial(obj.f_int_int, 1) if slot == "partial" else getattr(obj, slot)
    emitter.one_int.connect(cb)
    assert len(emitter.one_int) == 1
    emitter.one_int.emit(1)
    assert len(emitter.one_int) == 1
    emitter.one_int.disconnect(cb)
```