### PR TITLE
build: support 3.7 again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: v2.38.2
     hooks:
       - id: pyupgrade
-        args: [--py38-plus, --keep-runtime-typing]
+        args: [--py37-plus, --keep-runtime-typing]
 
   - repo: https://github.com/psf/black
     rev: 22.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 # https://peps.python.org/pep-0517/
 [build-system]
-requires = ["setuptools>=45", "wheel", "Cython==3.0.0a11", "setuptools-scm>=6.2"]
+requires = [
+    "setuptools>=45",
+    "wheel",
+    "Cython==3.0.0a11",
+    "setuptools-scm>=6.2",
+]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/
@@ -8,7 +13,7 @@ build-backend = "setuptools.build_meta"
 name = "psygnal"
 description = "Pure python callback/event system modeled after Qt Signals"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 license = { text = "BSD 3-Clause License" }
 authors = [{ email = "talley.lambert@gmail.com" }, { name = "Talley Lambert" }]
 classifiers = [
@@ -16,6 +21,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -23,7 +29,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["typing-extensions"]
+dependencies = [
+    "typing-extensions",
+    "importlib_metadata ; python_version < '3.8'",
+]
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
@@ -112,7 +121,7 @@ src_paths = ["src/psygnal", "tests"]
 exclude = "docs,.eggs,examples,_version.py"
 max-line-length = 88
 ignore = "E203"
-min-python-version = "3.8.0"
+min-python-version = "3.7.0"
 docstring-convention = "all" # use numpy convention, while allowing D417
 extend-ignore = """
  E203  # whitespace before ':'

--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -1,5 +1,8 @@
 """psygnal is a pure-python implementation of Qt-style signals & slots."""
-from importlib.metadata import PackageNotFoundError, version
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
 
 try:
     __version__ = version("psygnal")

--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -13,7 +13,6 @@ from typing import (
     Any,
     Callable,
     Iterator,
-    Literal,
     NoReturn,
     Type,
     Union,
@@ -25,7 +24,7 @@ from typing import (
 from typing_extensions import get_args, get_origin
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import Literal, Tuple
 
     MethodRef = Tuple[weakref.ReferenceType[object], str, Callable | None]
     NormedCallback = Union[MethodRef, Callable]
@@ -1089,7 +1088,7 @@ def signature(obj: Any) -> inspect.Signature:
         raise e from e
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def _stub_sig(obj: Any) -> Signature:
     import builtins
 

--- a/src/psygnal/_throttler.py
+++ b/src/psygnal/_throttler.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from threading import Timer
-from typing import TYPE_CHECKING, Any, Callable, Literal, overload
+from typing import TYPE_CHECKING, Any, Callable, overload
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from typing_extensions import ParamSpec
 
     P = ParamSpec("P")

--- a/src/psygnal/containers/_evented_set.py
+++ b/src/psygnal/containers/_evented_set.py
@@ -2,19 +2,9 @@ from __future__ import annotations
 
 from enum import Enum
 from itertools import chain
-from typing import (
-    Any,
-    Dict,
-    Final,
-    Iterable,
-    Iterator,
-    Literal,
-    MutableSet,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, Iterable, Iterator, MutableSet, Set, Tuple, TypeVar, Union
+
+from typing_extensions import Final, Literal
 
 from psygnal import Signal, SignalGroup
 

--- a/tests/test_evented_model.py
+++ b/tests/test_evented_model.py
@@ -1,10 +1,12 @@
 import inspect
-from typing import ClassVar, List, Protocol, Sequence, Union, runtime_checkable
+import sys
+from typing import ClassVar, List, Sequence, Union
 from unittest.mock import Mock
 
 import numpy as np
 import pytest
 from pydantic import PrivateAttr
+from typing_extensions import Protocol, runtime_checkable
 
 from psygnal import EventedModel, SignalGroup
 
@@ -55,6 +57,7 @@ def test_evented_model():
     name_mock.assert_not_called()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 def test_evented_model_array_updates():
     """Test updating an evented pydantic model with an array."""
 


### PR DESCRIPTION
adding back python 3.7 support.
I plan to follow [python's](https://devguide.python.org/versions/) end-of-life guides, rather than [numpy's](https://numpy.org/neps/nep-0029-deprecation_policy.html)

