### PR TITLE
Add support for other event loops

### DIFF
--- a/src/psygnal/__init__.py
+++ b/src/psygnal/__init__.py
@@ -31,8 +31,10 @@ __all__ = [
     "debounced",
     "emit_queued",
     "evented",
+    "get_async_backend",
     "get_evented_namespace",
     "is_evented",
+    "set_async_backend",
     "throttled",
 ]
 
@@ -48,6 +50,7 @@ if os.getenv("PSYGNAL_UNCOMPILED"):
         stacklevel=2,
     )
 
+from ._async import get_async_backend, set_async_backend
 from ._evented_decorator import evented
 from ._exceptions import EmitLoopError
 from ._group import EmissionInfo, SignalGroup

--- a/src/psygnal/_async.py
+++ b/src/psygnal/_async.py
@@ -1,0 +1,79 @@
+_async_backend = None
+
+
+def get_async_backend():
+    return _async_backend
+
+
+def set_async_backend(backend: str = "asyncio"):
+    global _async_backend
+
+    if _async_backend is not None:
+        raise RuntimeError(f"Async backend already set to: {_async_backend._backend}")
+
+    if backend == "asyncio":
+
+        import asyncio
+
+        class AsyncBackend:
+            def __init__(self):
+                self._backend = backend
+                self._queue = asyncio.Queue()
+                self.__running = False
+
+            @property
+            def _running(self) -> bool:
+                return self.__running
+
+            def _put(self, item) -> None:
+                self._queue.put_nowait(item)
+
+            async def _get(self):
+                return await self._queue.get()
+
+            async def run(self) -> None:
+                self.__running = True
+                while True:
+                    item = await self._get()
+                    cb = item[0]
+                    args = item[1:-1]
+                    kwargs = item[-1]
+                    await cb(*args, **kwargs)
+
+        _async_backend = AsyncBackend()
+
+    elif backend == "anyio":
+
+        import anyio
+
+        class AsyncBackend:
+            def __init__(self):
+                self._backend = backend
+                self._send_stream, self._receive_stream = anyio.create_memory_object_stream(max_buffer_size=float("inf"))
+                self.__running = False
+
+            @property
+            def _running(self) -> bool:
+                return self.__running
+
+            def _put(self, item) -> None:
+                self._send_stream.send_nowait(item)
+
+            async def _get(self):
+                return await self._receive_stream.receive()
+
+            async def run(self) -> None:
+                self.__running = True
+                async with self._receive_stream:
+                    async for item in self._receive_stream:
+                        cb = item[0]
+                        args = item[1:-1]
+                        kwargs = item[-1]
+                        await cb(*args, **kwargs)
+
+        _async_backend = AsyncBackend()
+
+    else:
+        raise RuntimeError(f"Async backend not supported: {backend}")
+
+    return _async_backend

--- a/src/psygnal/_async.py
+++ b/src/psygnal/_async.py
@@ -1,3 +1,7 @@
+from math import inf
+from abc import ABC, abstractmethod
+
+
 _async_backend = None
 
 
@@ -15,16 +19,11 @@ def set_async_backend(backend: str = "asyncio"):
 
         import asyncio
 
-        class AsyncBackend:
+        class AsyncBackend(_AsyncBackend):
             def __init__(self):
-                self._backend = backend
+                super().__init__(backend)
                 self._queue = asyncio.Queue()
-                self.__running = False
                 self._task = asyncio.create_task(self.run())
-
-            @property
-            def _running(self) -> bool:
-                return self.__running
 
             def _put(self, item) -> None:
                 self._queue.put_nowait(item)
@@ -39,26 +38,16 @@ def set_async_backend(backend: str = "asyncio"):
                 self.__running = True
                 while True:
                     item = await self._get()
-                    cb = item[0]
-                    args = item[1:-1]
-                    kwargs = item[-1]
-                    await cb(*args, **kwargs)
-
-        _async_backend = AsyncBackend()
+                    await self.call_back(item)
 
     elif backend == "anyio":
 
         import anyio
 
-        class AsyncBackend:
+        class AsyncBackend(_AsyncBackend):
             def __init__(self):
-                self._backend = backend
-                self._send_stream, self._receive_stream = anyio.create_memory_object_stream(max_buffer_size=float("inf"))
-                self.__running = False
-
-            @property
-            def _running(self) -> bool:
-                return self.__running
+                super().__init__(backend)
+                self._send_stream, self._receive_stream = anyio.create_memory_object_stream(max_buffer_size=inf)
 
             def _put(self, item) -> None:
                 self._send_stream.send_nowait(item)
@@ -73,14 +62,63 @@ def set_async_backend(backend: str = "asyncio"):
                 self.__running = True
                 async with self._receive_stream:
                     async for item in self._receive_stream:
-                        cb = item[0]
-                        args = item[1:-1]
-                        kwargs = item[-1]
-                        await cb(*args, **kwargs)
+                        await self.call_back(item)
+
+    elif backend == "trio":
+
+        import trio
+
+        class AsyncBackend(_AsyncBackend):
+            def __init__(self):
+                super().__init__(backend)
+                self._send_channel, self._receive_channel = trio.open_memory_channel(max_buffer_size=inf)
+
+            def _put(self, item) -> None:
+                self._send_channel.send_nowait(item)
+
+            async def _get(self):
+                return await self._receive_channel.receive()
+
+            async def run(self) -> None:
+                if self.__running:
+                    return
+
+                self.__running = True
+                async for item in self._receive_channel:
+                    await self.call_back(item)
 
         _async_backend = AsyncBackend()
 
     else:
         raise RuntimeError(f"Async backend not supported: {backend}")
 
+    _async_backend = AsyncBackend()
     return _async_backend
+
+
+class _AsyncBackend(ABC):
+    def __init__(self, backend: str):
+        self._backend = backend
+        self.__running = False
+
+    @property
+    def _running(self) -> bool:
+        return self.__running
+
+    @abstractmethod
+    def _put(self, item) -> None:
+        ...
+
+    @abstractmethod
+    async def _get(self):
+        ...
+
+    @abstractmethod
+    async def run(self) -> None:
+        ...
+
+    async def call_back(self, item) -> None:
+        cb = item[0]
+        args = item[1:-1]
+        kwargs = item[-1]
+        await cb(*args, **kwargs)

--- a/src/psygnal/_async.py
+++ b/src/psygnal/_async.py
@@ -20,6 +20,7 @@ def set_async_backend(backend: str = "asyncio"):
                 self._backend = backend
                 self._queue = asyncio.Queue()
                 self.__running = False
+                self._task = asyncio.create_task(self.run())
 
             @property
             def _running(self) -> bool:
@@ -32,6 +33,9 @@ def set_async_backend(backend: str = "asyncio"):
                 return await self._queue.get()
 
             async def run(self) -> None:
+                if self.__running:
+                    return
+
                 self.__running = True
                 while True:
                     item = await self._get()
@@ -63,6 +67,9 @@ def set_async_backend(backend: str = "asyncio"):
                 return await self._receive_stream.receive()
 
             async def run(self) -> None:
+                if self.__running:
+                    return
+
                 self.__running = True
                 async with self._receive_stream:
                     async for item in self._receive_stream:


### PR DESCRIPTION
Sorry for the long silence @tlambert03. This is what I have in mind for supporting other event loops than asyncio. Right now it only adds support for AnyIO, but we could add Trio too (if people want to use Trio not through AnyIO).
Basically, users have to call `set_async_backend()` with the backend of their choice (`"asyncio"` or `"anyio"`). This should be done as early as possible, and only once. It means this PR only supports one global event loop, which I think is good enough, but we could improve it to support multiple event loops in the future.
Then users must launch the `get_async_backend().run` coroutine in a background task. This part is event-loop specific. For asyncio, that would be `asyncio.create_task(get_async_backend().run())`. For AnyIO, that would be `tg.start_soon(get_async_backend().run)`, supposing they got a task group `tg` somehow.
Let me know what you think. The PR is not polished but this is the idea.